### PR TITLE
fix(bubble-bobble): auto-pause on sign in + word overlay + Enter pause

### DIFF
--- a/games/bubble-bobble/index.html
+++ b/games/bubble-bobble/index.html
@@ -341,7 +341,7 @@ window.addEventListener('keydown', e => {
   if (e.code==='ArrowUp')                                    pressed.add('menuup');
   if (e.code==='ArrowDown')                                 { pressed.add('menudown'); e.preventDefault(); }
   if (e.code==='KeyX'     || e.code==='Space')             { pressed.add('shoot');   e.preventDefault(); }
-  if (e.code==='Enter')                                    { pressed.add('enter'); if(paused) togglePause(); }
+  if (e.code==='Enter')                                    { pressed.add('enter'); if(gs.state==='playing'||gs.state==='harvest'||paused) togglePause(); }
   if (e.code==='KeyN')                                       pressed.add('newgame');
   if (e.code==='KeyP' || e.code==='Escape')                  togglePause();
 });

--- a/games/bubble-bobble/index.html
+++ b/games/bubble-bobble/index.html
@@ -994,14 +994,14 @@ function drawLifeBubble(ctx, lb) {
 function drawWordComplete(ctx) {
   const a=Math.min(wordCompleteTimer/30,1);
   ctx.save(); ctx.globalAlpha=a;
-  ctx.fillStyle='rgba(0,0,20,0.75)'; ctx.fillRect(0,CH/2-62,CW,100);
+  ctx.fillStyle='rgba(0,0,20,0.75)'; ctx.fillRect(0,0,CW,90);
   ctx.textAlign='center';
   ctx.fillStyle='#f5c518'; ctx.font='bold 13px monospace';
-  ctx.fillText('✨  W O R D  C O M P L E T E !  ✨',CW/2,CH/2-36);
+  ctx.fillText('✨  W O R D  C O M P L E T E !  ✨',CW/2,22);
   ctx.fillStyle='#4ecdc4'; ctx.font=`bold 30px monospace`;
-  ctx.fillText(currentWord,CW/2,CH/2+4);
+  ctx.fillText(currentWord,CW/2,58);
   ctx.fillStyle='#aaa'; ctx.font='10px monospace';
-  ctx.fillText('+500 BONUS!',CW/2,CH/2+26);
+  ctx.fillText('+500 BONUS!',CW/2,78);
   ctx.restore();
 }
 
@@ -1417,6 +1417,9 @@ auth.onAuthStateChanged(async user => {
 });
 
 function googleSignIn() {
+  if (gs.state === 'playing' || gs.state === 'harvest') {
+    if (!paused) togglePause();
+  }
   const provider = new firebase.auth.GoogleAuthProvider();
   auth.signInWithPopup(provider).catch(e => console.warn('Sign-in failed', e));
 }

--- a/games/bubble-bobble/index.html
+++ b/games/bubble-bobble/index.html
@@ -341,7 +341,7 @@ window.addEventListener('keydown', e => {
   if (e.code==='ArrowUp')                                    pressed.add('menuup');
   if (e.code==='ArrowDown')                                 { pressed.add('menudown'); e.preventDefault(); }
   if (e.code==='KeyX'     || e.code==='Space')             { pressed.add('shoot');   e.preventDefault(); }
-  if (e.code==='Enter')                                      pressed.add('enter');
+  if (e.code==='Enter')                                    { pressed.add('enter'); if(paused) togglePause(); }
   if (e.code==='KeyN')                                       pressed.add('newgame');
   if (e.code==='KeyP' || e.code==='Escape')                  togglePause();
 });
@@ -994,14 +994,12 @@ function drawLifeBubble(ctx, lb) {
 function drawWordComplete(ctx) {
   const a=Math.min(wordCompleteTimer/30,1);
   ctx.save(); ctx.globalAlpha=a;
-  ctx.fillStyle='rgba(0,0,20,0.75)'; ctx.fillRect(0,0,CW,90);
+  ctx.fillStyle='rgba(0,0,20,0.75)'; ctx.fillRect(0,TILE*2,CW,70);
   ctx.textAlign='center';
-  ctx.fillStyle='#f5c518'; ctx.font='bold 13px monospace';
-  ctx.fillText('✨  W O R D  C O M P L E T E !  ✨',CW/2,22);
-  ctx.fillStyle='#4ecdc4'; ctx.font=`bold 30px monospace`;
-  ctx.fillText(currentWord,CW/2,58);
-  ctx.fillStyle='#aaa'; ctx.font='10px monospace';
-  ctx.fillText('+500 BONUS!',CW/2,78);
+  ctx.fillStyle='#4ecdc4'; ctx.font=`bold 28px monospace`;
+  ctx.fillText(currentWord,CW/2,TILE*2+42);
+  ctx.fillStyle='#f5c518'; ctx.font='10px monospace';
+  ctx.fillText('+500 BONUS!',CW/2,TILE*2+60);
   ctx.restore();
 }
 

--- a/games/bubble-bobble/index.html
+++ b/games/bubble-bobble/index.html
@@ -994,7 +994,7 @@ function drawLifeBubble(ctx, lb) {
 function drawWordComplete(ctx) {
   const a=Math.min(wordCompleteTimer/30,1);
   ctx.save(); ctx.globalAlpha=a;
-  ctx.fillStyle='rgba(0,0,20,0.75)'; ctx.fillRect(0,TILE*2,CW,70);
+  // no background — canvas is already dark
   ctx.textAlign='center';
   ctx.fillStyle='#4ecdc4'; ctx.font=`bold 28px monospace`;
   ctx.fillText(currentWord,CW/2,TILE*2+42);
@@ -1345,7 +1345,7 @@ function drawPaused(ctx) {
   ctx.fillStyle='rgba(0,0,0,0.6)'; ctx.fillRect(0,0,CW,CH);
   ctx.textAlign='center';
   ctx.fillStyle='#4ecdc4'; ctx.font='bold 28px monospace'; ctx.fillText('PAUSED',CW/2,CH/2-16);
-  ctx.fillStyle='#aaa'; ctx.font='12px monospace'; ctx.fillText('P / ESC or ▶ RESUME to continue',CW/2,CH/2+16);
+  ctx.fillStyle='#aaa'; ctx.font='12px monospace'; ctx.fillText('P / ESC / Enter or ▶ RESUME',CW/2,CH/2+16);
 }
 
 // Init


### PR DESCRIPTION
## Summary
- Auto-pause game when Google Sign In popup opens
- Enter key toggles pause during playing/harvest state
- Word complete overlay simplified: just word + bonus text, no background
- PAUSED screen hint updated to include Enter key

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)