### PR TITLE
Platform auth, unified EXIT buttons, avatar, save/resume, visit counter

### DIFF
--- a/games/blocks-classic/index.html
+++ b/games/blocks-classic/index.html
@@ -253,14 +253,16 @@
       z-index: 150;
     }
     .pause-badge.visible { display: block; }
+    #game-avatar{position:fixed;top:12px;right:12px;z-index:999;}
   </style>
 </head>
 <body>
+<div id="game-avatar"></div>
 
 <!-- TOP BAR -->
 <div class="topbar">
   <div class="brand">
-    <a href="../../index.html">🎮 GameZone</a>
+    <a href="/">🎮 GameZone</a>
     <span class="sep">/</span>
     <span>Blocks Classic</span>
   </div>
@@ -268,7 +270,7 @@
     <button class="btn btn-ghost" id="howToPlayBtn">How to Play</button>
     <button class="btn btn-ghost" id="pauseBtn">⏸ Pause</button>
     <button class="btn btn-ghost" id="restartBtn">↺ Restart</button>
-    <button class="btn btn-danger" id="exitBtn">✕ Exit</button>
+    <button class="btn btn-danger" id="exitBtn">✕ EXIT</button>
   </div>
 </div>
 
@@ -347,7 +349,7 @@
     </p>
     <div class="modal-buttons">
       <button class="btn btn-primary" id="gameOverRestartBtn">↺ Play Again</button>
-      <button class="btn btn-ghost" id="gameOverExitBtn">🏠 Home</button>
+      <button class="btn btn-danger" id="gameOverExitBtn">✕ EXIT</button>
     </div>
   </div>
 </div>
@@ -776,7 +778,7 @@ document.getElementById('restartBtn').addEventListener('click', () => {
   initGame();
 });
 document.getElementById('exitBtn').addEventListener('click', () => {
-  window.location.href = '../../index.html';
+  window.location.href = '/';
 });
 document.getElementById('gameOverRestartBtn').addEventListener('click', () => {
   document.getElementById('gameOverOverlay').classList.remove('active');
@@ -785,7 +787,7 @@ document.getElementById('gameOverRestartBtn').addEventListener('click', () => {
   initGame();
 });
 document.getElementById('gameOverExitBtn').addEventListener('click', () => {
-  window.location.href = '../../index.html';
+  window.location.href = '/';
 });
 document.getElementById('howToPlayBtn').addEventListener('click', () => {
   if (gameRunning && !paused) togglePause();
@@ -808,6 +810,13 @@ currentPiece = randomPiece();
 currentX = 3; currentY = 0;
 score = 0; level = 1; lines = 0;
 draw();
+</script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+<script src="../shared/firebase.js"></script>
+<script>
+SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
 </script>
 </body>
 </html>

--- a/games/bounce-rush/index.html
+++ b/games/bounce-rush/index.html
@@ -112,14 +112,16 @@
   .lvl-btn:hover  { background: #22224a; color: #e2e8f0; }
   .lvl-btn.active { background: #7c3aed; border-color: #a78bfa; color: #fff; }
   .lvl-btn.done   { border-color: #22c55e; color: #4ade80; }
+  #game-avatar{position:fixed;top:12px;right:12px;z-index:999;}
 </style>
 </head>
 <body>
+<div id="game-avatar"></div>
 
 <div class="topbar">
-  <a class="topbar-home" href="../../index.html">🏠</a>
   <div class="topbar-title">🟡 Bounce Rush</div>
   <button class="topbar-btn" id="soundBtn">🔊</button>
+  <button class="topbar-btn" id="exitBtn" onclick="window.location.href='/'" style="background:linear-gradient(135deg,#dc2626,#991b1b);color:#fff;border-color:#991b1b;">✕ EXIT</button>
 </div>
 
 <div class="game-area">
@@ -1008,6 +1010,13 @@ document.getElementById('restartBtn').addEventListener('click', () => {
 
 // Launch with modal
 openModal(false);
+</script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+<script src="../shared/firebase.js"></script>
+<script>
+SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
 </script>
 </body>
 </html>

--- a/games/bubble-bobble/index.html
+++ b/games/bubble-bobble/index.html
@@ -25,15 +25,12 @@ canvas{display:block;border:2px solid #2a2a50;border-top:none;border-bottom:none
 .gbtn{background:#1c1c38;border:1px solid #3a3a60;color:#ccc;font-family:monospace;font-size:10px;padding:3px 10px;border-radius:4px;cursor:pointer;letter-spacing:.5px;transition:background 0.15s,color 0.15s}
 .gbtn:hover{background:#2a2a55;color:#fff}
 .gbtn.pause-btn{color:#4ecdc4;border-color:#4ecdc4}
-.gbtn.exit-btn{color:#ff6b6b;border-color:#ff6b6b}
-.gbtn.google-btn{color:#fff;border-color:#4285f4;background:#1c1c38}
-.gbtn.google-btn:hover{background:#4285f4}
-.gbtn.signout-btn{color:#aaa;border-color:#555;font-size:9px;padding:2px 7px}
-#auth-status{font-size:10px;color:#4ecdc4;display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-bottom:6px}
-#auth-bar{margin-top:4px}
+.gbtn.exit-btn{background:linear-gradient(135deg,#dc2626,#991b1b);color:#fff;border-color:#991b1b;}
+#game-avatar{position:fixed;top:12px;right:12px;z-index:999;}
 </style>
 </head>
 <body>
+<div id="game-avatar"></div>
 <div id="layout">
   <div id="sidebar-left">
     <h2>Controls</h2>
@@ -56,9 +53,6 @@ canvas{display:block;border:2px solid #2a2a50;border-top:none;border-bottom:none
     <br>
     <div id="word-progress" style="text-align:center"></div>
     <br>
-    <div id="auth-bar" style="text-align:center">
-      <button class="gbtn google-btn" onclick="bbSignIn()">Google Sign In</button>
-    </div>
   </div>
 
   <div id="game-col">
@@ -324,7 +318,8 @@ function consume(k) { if(pressed.has(k)){pressed.delete(k);return true;} return 
 // ─── Save / Load ─────────────────────────────────────────────
 const SAVE_KEY = 'bubbleBobbleSave';
 function saveProgress() {
-  const data = { level:gs.level, score:gs.score, lives:gs.lives, wordStreak:gs.wordStreak, savedAt:Date.now() };
+  const uid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser) ? SillyFirebase.currentUser.uid : null;
+  const data = { level:gs.level, score:gs.score, lives:gs.lives, wordStreak:gs.wordStreak, savedAt:Date.now(), uid };
   localStorage.setItem(SAVE_KEY, JSON.stringify(data));
   if (typeof SillyFirebase !== 'undefined') SillyFirebase.saveProgress('bubbleBobble', data);
 }
@@ -352,14 +347,14 @@ function togglePause() {
   // Clear stale inputs when resuming so held keys don't fire
   if (!paused) { pressed.clear(); keys.left=false; keys.right=false; }
 }
-function exitToTitle() {
-  paused = false;
-  gs.state = 'title';
-  titleCursor = 0;
-  bubbles=[]; fruits=[]; enemies=[]; letterBubbles=[]; popups=[]; lifeBubble=null; giantFruit=null;
-  pressed.clear(); keys.left=false; keys.right=false;
-  const btn = document.getElementById('pauseBtn');
-  if (btn) btn.textContent = '⏸ PAUSE';
+async function exitToTitle() {
+  if (gs.state === 'playing' || gs.state === 'harvest') {
+    const uid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser) ? SillyFirebase.currentUser.uid : null;
+    const data = { level:gs.level, score:gs.score, lives:gs.lives, wordStreak:gs.wordStreak, savedAt:Date.now(), uid };
+    localStorage.setItem(SAVE_KEY, JSON.stringify(data));
+    if (typeof SillyFirebase !== 'undefined') await SillyFirebase.saveProgress('bubbleBobble', data);
+  }
+  window.location.href = '/';
 }
 
 // ─── Player ──────────────────────────────────────────────────
@@ -881,7 +876,8 @@ function drawTitle(ctx, frame) {
   ctx.fillStyle='#f5c518'; ctx.font='bold 36px monospace'; ctx.fillText('BUBBLE',CW/2,CH/2-50);
   ctx.fillStyle='#4ecdc4'; ctx.font='bold 36px monospace'; ctx.fillText('BOBBLE',CW/2,CH/2-10);
   const sv = loadSave();
-  if(sv){
+  const _currentUid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser) ? SillyFirebase.currentUser.uid : null;
+  if(sv && sv.uid === _currentUid){
     const opts = [
       { label:'Continue (Level '+String(sv.level).padStart(2,'0')+')', color:'#4ecdc4' },
       { label:'New Game',                                               color:'#ff6b6b' }
@@ -1164,7 +1160,9 @@ function update() {
   frame++;
   if(gs.state==='title'){
     const sv = loadSave();
-    if(sv){
+    const _uid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser) ? SillyFirebase.currentUser.uid : null;
+    const svOwned = sv && sv.uid === _uid;
+    if(svOwned){
       if(consume('menuup'))   titleCursor = 0;
       if(consume('menudown')) titleCursor = 1;
       if(consume('newgame'))  titleCursor = 1;
@@ -1249,7 +1247,7 @@ function update() {
   // player vs enemy
   if(!player.dead && player.invincible===0){
     for(const e of enemies){
-      if(e.touches(player)){ if(player.die()){ gs.lives--; if(gs.lives<=0){ gs.state='gameOver'; const gd={level:Math.max(1,gs.level-3),score:0,lives:3,wordStreak:gs.wordStreak,savedAt:Date.now()}; localStorage.setItem(SAVE_KEY,JSON.stringify(gd)); if(typeof SillyFirebase!=='undefined') SillyFirebase.saveProgress('bubbleBobble',gd); } else { saveProgress(); } } break; }
+      if(e.touches(player)){ if(player.die()){ gs.lives--; if(gs.lives<=0){ gs.state='gameOver'; const _uid=(typeof SillyFirebase!=='undefined'&&SillyFirebase.currentUser)?SillyFirebase.currentUser.uid:null; const gd={level:Math.max(1,gs.level-3),score:0,lives:3,wordStreak:gs.wordStreak,savedAt:Date.now(),uid:_uid}; localStorage.setItem(SAVE_KEY,JSON.stringify(gd)); if(typeof SillyFirebase!=='undefined') SillyFirebase.saveProgress('bubbleBobble',gd); } else { saveProgress(); } } break; }
     }
   }
 
@@ -1362,16 +1360,17 @@ updateHUD();
 <script src="../shared/firebase.js"></script>
 <script>
 // ─── Bubble Bobble Firebase wiring ───────────────────────────
-function bbSignIn() {
-  if (gs.state === 'playing' || gs.state === 'harvest') {
-    if (!paused) togglePause();
-  }
-  SillyFirebase.signIn();
-}
-
+let _bbAuthReady = false;
 SillyFirebase.onAuthChanged(async user => {
-  if (user) await SillyFirebase.syncProgress('bubbleBobble', SAVE_KEY);
-  SillyFirebase.renderAuthBar('auth-bar', 'bbSignIn()');
+  if (user) {
+    _bbAuthReady = true;
+    await SillyFirebase.syncProgress('bubbleBobble', SAVE_KEY);
+  } else if (_bbAuthReady) {
+    // Real sign-out (not the initial null flash on page load)
+    clearSave();
+  }
+  _bbAuthReady = true;
+  SillyFirebase.renderAvatar('game-avatar', user);
 });
 </script>
 </body>

--- a/games/bubble-shooter/index.html
+++ b/games/bubble-shooter/index.html
@@ -197,21 +197,23 @@
 
     /* Aim line glow */
     #gameCanvas { box-shadow: 0 0 30px rgba(6,182,212,0.1); }
+    #game-avatar{position:fixed;top:12px;right:12px;z-index:999;}
   </style>
 </head>
 <body>
+<div id="game-avatar"></div>
 
 <!-- TOP BAR -->
 <div class="topbar">
   <div class="brand">
-    <a href="../../index.html">🎮 GameZone</a>
+    <a href="/">🎮 GameZone</a>
     <span class="sep">/</span>
     <span>Bubble Shooter</span>
   </div>
   <div class="topbar-actions">
     <button class="btn btn-ghost" id="howToPlayBtn">How to Play</button>
     <button class="btn btn-ghost" id="restartBtn">↺ Restart</button>
-    <button class="btn btn-danger" id="exitBtn">✕ Exit</button>
+    <button class="btn btn-danger" id="exitBtn">✕ EXIT</button>
   </div>
 </div>
 
@@ -291,7 +293,7 @@
     <p style="font-size:0.82rem;color:var(--muted);margin-bottom:1.2rem" id="resultDetail"></p>
     <div class="modal-buttons">
       <button class="btn btn-primary" id="resultRestartBtn">↺ Play Again</button>
-      <button class="btn btn-ghost" id="resultExitBtn">🏠 Home</button>
+      <button class="btn btn-danger" id="resultExitBtn">✕ EXIT</button>
     </div>
   </div>
 </div>
@@ -980,7 +982,7 @@ document.getElementById('restartBtn').addEventListener('click', () => {
   initGame();
 });
 document.getElementById('exitBtn').addEventListener('click', () => {
-  window.location.href = '../../index.html';
+  window.location.href = '/';
 });
 document.getElementById('howToPlayBtn').addEventListener('click', () => {
   if (gameRunning) {
@@ -1003,7 +1005,7 @@ document.getElementById('resultRestartBtn').addEventListener('click', () => {
   initGame();
 });
 document.getElementById('resultExitBtn').addEventListener('click', () => {
-  window.location.href = '../../index.html';
+  window.location.href = '/';
 });
 
 // ─────────────────────────────────────────────
@@ -1014,6 +1016,13 @@ score = 0; shotsCount = 0;
 currentColor = 0; nextColor = 1;
 draw();
 drawNextBubble();
+</script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+<script src="../shared/firebase.js"></script>
+<script>
+SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
 </script>
 </body>
 </html>

--- a/games/count-masters/index.html
+++ b/games/count-masters/index.html
@@ -154,14 +154,16 @@
       font-size: 0.78rem; color: var(--muted);
     }
     .legend-dot { width: 12px; height: 12px; border-radius: 3px; flex-shrink: 0; }
+    #game-avatar{position:fixed;top:12px;right:12px;z-index:999;}
   </style>
 </head>
 <body>
+<div id="game-avatar"></div>
 
 <!-- TOP BAR -->
 <div class="topbar">
   <div class="brand">
-    <a href="../../index.html">🎮 GameZone</a>
+    <a href="/">🎮 GameZone</a>
     <span class="sep">/</span>
     <span>Count Masters</span>
   </div>
@@ -169,7 +171,7 @@
     <button class="btn btn-ghost" id="howToPlayBtn">How to Play</button>
     <button class="btn btn-ghost" id="pauseBtn">⏸ Pause</button>
     <button class="btn btn-ghost" id="restartBtn">↺ Restart</button>
-    <button class="btn btn-danger" id="exitBtn">✕ Exit</button>
+    <button class="btn btn-danger" id="exitBtn">✕ EXIT</button>
   </div>
 </div>
 
@@ -267,7 +269,7 @@
     <div class="modal-buttons">
       <button class="btn btn-primary" id="resultContinueBtn" style="display:none">Next Level ▶</button>
       <button class="btn btn-primary" id="resultRestartBtn">↺ Play Again</button>
-      <button class="btn btn-ghost" id="resultExitBtn">🏠 Home</button>
+      <button class="btn btn-danger" id="resultExitBtn">✕ EXIT</button>
     </div>
   </div>
 </div>
@@ -1366,8 +1368,8 @@ document.getElementById('resultRestartBtn').addEventListener('click', () => {
   initGame();
 });
 
-document.getElementById('exitBtn').addEventListener('click',       () => { window.location.href = '../../index.html'; });
-document.getElementById('resultExitBtn').addEventListener('click', () => { window.location.href = '../../index.html'; });
+document.getElementById('exitBtn').addEventListener('click',       () => { window.location.href = '/'; });
+document.getElementById('resultExitBtn').addEventListener('click', () => { window.location.href = '/'; });
 
 // ═══════════════════════════════════════════════
 //  BOOT — draw preview while modal open
@@ -1378,6 +1380,13 @@ document.getElementById('resultExitBtn').addEventListener('click', () => { windo
   drawCrowd(VP_X, CROWD_Y, 10, af, '#e2e8f0');
   drawCountBadge(VP_X, CROWD_Y + 28, 10, '#06b6d4', 'rgba(5,20,40,0.85)');
 })();
+</script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+<script src="../shared/firebase.js"></script>
+<script>
+SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
 </script>
 </body>
 </html>

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -11,9 +11,16 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   min-height: 100vh;
   font-family: 'Courier New', monospace;
+}
+#pac-topbar {
+  width: 576px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 18px 4px 2px;
 }
 canvas {
   display: block;
@@ -21,16 +28,20 @@ canvas {
 }
 .gbtn{background:#1c1c38;border:1px solid #3a3a60;color:#ccc;font-family:monospace;font-size:10px;padding:3px 10px;border-radius:4px;cursor:pointer;letter-spacing:.5px;transition:background 0.15s,color 0.15s}
 .gbtn:hover{background:#2a2a55;color:#fff}
-.gbtn.google-btn{color:#fff;border-color:#4285f4;background:#1c1c38}
-.gbtn.google-btn:hover{background:#4285f4}
-.gbtn.signout-btn{color:#aaa;border-color:#555;font-size:9px;padding:2px 7px}
-#auth-bar{margin-top:8px;text-align:center;width:576px}
-#auth-status{font-size:10px;color:#4ecdc4;display:block;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;margin-bottom:6px}
+#game-avatar{position:fixed;top:12px;right:12px;z-index:999;}
+#pac-exit-btn{background:linear-gradient(135deg,#dc2626,#991b1b);border:1px solid #991b1b;color:#fff;font-family:monospace;font-size:0.85rem;padding:0.45rem 1rem;border-radius:8px;cursor:pointer;letter-spacing:.5px;transition:opacity 0.15s;}
+#pac-exit-btn:hover{opacity:0.85;}
+#pac-canvas-wrap{position:relative;display:inline-block;}
 </style>
 </head>
 <body>
-<canvas id="c" width="576" height="412"></canvas><!-- 352 maze + 60 tray -->
-<div id="auth-bar"><button class="gbtn google-btn" onclick="pacSignIn()">Google Sign In</button></div>
+<div id="game-avatar"></div>
+<div id="pac-topbar">
+  <button id="pac-exit-btn">✕ EXIT</button>
+</div>
+<div id="pac-canvas-wrap">
+  <canvas id="c" width="576" height="412"></canvas><!-- 352 maze + 60 tray -->
+</div>
 <script src="../shared/words.js"></script>
 <script>
 // ═══════════════════════════════════════════════════════════
@@ -420,7 +431,22 @@ document.addEventListener('keydown', e => {
   if (map[e.key]) { e.preventDefault(); pac.next = map[e.key]; }
   if (e.key === 'Enter') {
     if (paused) { paused = false; }
-    else if (!gameRunning || gameOver || youWin) startGame();
+    else if (gameOver || youWin) { startGame(); }
+    else if (!gameRunning) {
+      if (savedLevel > 1) {
+        if (titleCursor === 1) { clearProgress(); }
+        startGame();
+      } else {
+        startGame();
+      }
+    }
+  }
+  if (!gameRunning && !gameOver && !youWin && savedLevel > 1) {
+    if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+      e.preventDefault();
+      titleCursor = e.key === 'ArrowUp' ? 0 : 1;
+      drawMaze(); drawPac(); drawTray(); drawSoundIcon(); drawStartPrompt();
+    }
   }
   if ((e.key === 'p' || e.key === 'P' || e.key === 'Escape') &&
       gameRunning && !gameOver && !dying) {
@@ -498,17 +524,27 @@ let youWin          = false;
 let levelClearTimer = 0;
 let wordsThisLevel  = 0;
 let highScore       = parseInt(localStorage.getItem('pacman_hs') || '0', 10);
-
 const PAC_SAVE_KEY = 'pacman_save';
+let savedLevel      = (() => {
+  try { return JSON.parse(localStorage.getItem(PAC_SAVE_KEY))?.currentLevel || 1; } catch(e) { return 1; }
+})();
+let titleCursor     = 0; // 0 = Continue, 1 = New Game
 
-function saveHighScore() {
+function saveProgress() {
   if (score > highScore) {
     highScore = score;
     localStorage.setItem('pacman_hs', highScore);
   }
-  const data = { highScore, savedAt: Date.now() };
+  const data = { highScore, currentLevel: level, savedAt: Date.now() };
   localStorage.setItem(PAC_SAVE_KEY, JSON.stringify(data));
   if (typeof SillyFirebase !== 'undefined') SillyFirebase.saveProgress('pacMan', data);
+}
+
+function clearProgress() {
+  savedLevel = 1;
+  localStorage.removeItem(PAC_SAVE_KEY);
+  if (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser)
+    SillyFirebase.saveProgress('pacMan', { highScore, currentLevel: 1, savedAt: Date.now() });
 }
 
 function startLevel() {
@@ -533,7 +569,7 @@ function startLevel() {
 }
 
 function startGame() {
-  level    = 1;
+  level    = savedLevel;
   lives    = 3;
   score    = 0;
   gameOver = false;
@@ -626,7 +662,7 @@ function drawPac() {
 
 function drawStartPrompt() {
   ctx.fillStyle = 'rgba(0,0,0,0.72)';
-  ctx.fillRect(0, CH / 2 - 70, CW, 140);
+  ctx.fillRect(0, CH / 2 - 70, CW, 150);
   ctx.textAlign = 'center';
   // Title
   ctx.fillStyle = '#FFD700';
@@ -636,10 +672,28 @@ function drawStartPrompt() {
   ctx.fillStyle = '#aaa';
   ctx.font = '14px "Courier New", monospace';
   ctx.fillText('HIGH SCORE: ' + highScore, CW / 2, CH / 2);
-  // Prompt
-  ctx.fillStyle = '#FFD700';
-  ctx.font = 'bold 18px "Courier New", monospace';
-  ctx.fillText('Press ENTER to Start', CW / 2, CH / 2 + 34);
+  if (savedLevel > 1) {
+    // Two-option menu
+    const opts = [
+      `Continue (Level ${String(savedLevel).padStart(2, '0')})`,
+      'New Game'
+    ];
+    const colors = ['#4ecdc4', '#ff6b6b'];
+    opts.forEach((label, i) => {
+      const y = CH / 2 + 30 + i * 26;
+      const selected = titleCursor === i;
+      ctx.font = (selected ? 'bold ' : '') + '14px "Courier New", monospace';
+      ctx.fillStyle = selected ? colors[i] : '#555';
+      ctx.fillText((selected ? '▶ ' : '  ') + label, CW / 2, y);
+    });
+    ctx.fillStyle = '#444';
+    ctx.font = '10px "Courier New", monospace';
+    ctx.fillText('↑ ↓ to select   ENTER to confirm', CW / 2, CH / 2 + 90);
+  } else {
+    ctx.fillStyle = '#FFD700';
+    ctx.font = 'bold 18px "Courier New", monospace';
+    ctx.fillText('Press ENTER to Start', CW / 2, CH / 2 + 34);
+  }
 }
 
 function drawScore() {
@@ -769,7 +823,8 @@ function loop(now) {
       if (level >= 50) {
         youWin = true;
         levelClear = false;
-        saveHighScore();
+        saveProgress();
+        clearProgress();
       } else {
         level++;
         startLevel();
@@ -1084,7 +1139,8 @@ function checkGhostCollision() {
         if (lives <= 0) {
           gameOver = true;
           dying = false;
-          saveHighScore();
+          saveProgress();
+          clearProgress();
         } else {
           pac.x = SPAWN_X; pac.y = SPAWN_Y;
           pac.dir = null; pac.next = 'r';
@@ -1463,10 +1519,10 @@ drawStartPrompt();
 <script src="../shared/firebase.js"></script>
 <script>
 // ─── Pac-Man Firebase wiring ──────────────────────────────
-function pacSignIn() {
-  if (gameRunning && !gameOver && !paused) paused = true;
-  SillyFirebase.signIn();
-}
+document.getElementById('pac-exit-btn').addEventListener('click', () => {
+  if (gameRunning && !gameOver && !youWin) saveProgress();
+  window.location.href = '/';
+});
 
 SillyFirebase.onAuthChanged(async user => {
   if (user) {
@@ -1474,19 +1530,32 @@ SillyFirebase.onAuthChanged(async user => {
     let local = null;
     try { local = JSON.parse(localStorage.getItem(PAC_SAVE_KEY)); } catch(e) {}
 
-    if (cloud || local) {
-      const cloudHS = cloud ? (cloud.highScore || 0) : 0;
-      const localHS = local ? (local.highScore || 0) : 0;
-      if (cloudHS > localHS) {
-        highScore = cloudHS;
-        localStorage.setItem('pacman_hs', highScore);
-        localStorage.setItem(PAC_SAVE_KEY, JSON.stringify(cloud));
-      } else if (localHS > cloudHS) {
+    let best = null;
+    if (cloud && local) {
+      best = (cloud.savedAt || 0) > (local.savedAt || 0) ? cloud : local;
+    } else {
+      best = cloud || local;
+    }
+    if (best) {
+      highScore = best.highScore || 0;
+      savedLevel = best.currentLevel || 1;
+      localStorage.setItem('pacman_hs', highScore);
+      localStorage.setItem(PAC_SAVE_KEY, JSON.stringify(best));
+      if ((cloud && local) && (local.savedAt || 0) > (cloud.savedAt || 0)) {
         await SillyFirebase.saveProgress('pacMan', local);
       }
     }
+  } else {
+    // Guest — read from localStorage (may have guest save)
+    try {
+      const local = JSON.parse(localStorage.getItem(PAC_SAVE_KEY));
+      if (local) { savedLevel = local.currentLevel || 1; highScore = local.highScore || 0; }
+      else { savedLevel = 1; }
+    } catch(e) { savedLevel = 1; }
   }
-  SillyFirebase.renderAuthBar('auth-bar', 'pacSignIn()');
+  // Re-draw title screen if game hasn't started yet
+  if (!gameRunning) { drawMaze(); drawPac(); drawTray(); drawSoundIcon(); drawStartPrompt(); }
+  SillyFirebase.renderAvatar('game-avatar', user);
 });
 </script>
 </body>

--- a/games/ping-pong/index.html
+++ b/games/ping-pong/index.html
@@ -33,6 +33,7 @@
     .btn-ghost { background: transparent; border: 1px solid var(--border); color: var(--text); }
     .btn-ghost:hover { border-color: var(--accent); }
     .btn-primary { background: linear-gradient(135deg, var(--accent), #5b21b6); color: #fff; }
+    .btn-danger { background: linear-gradient(135deg, #dc2626, #991b1b); color: #fff; }
 
     .sound-toggle {
       background: transparent; border: 1px solid var(--border); color: var(--text);
@@ -114,13 +115,15 @@
     }
     .diff-pill:hover { border-color: var(--accent); color: var(--text); }
     .diff-pill.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+    #game-avatar{position:fixed;top:12px;right:12px;z-index:999;}
   </style>
 </head>
 <body>
+<div id="game-avatar"></div>
 
 <div class="topbar">
   <div class="brand">
-    <a href="../../index.html">🏠</a>
+    <a href="/">🏠</a>
     <span class="sep">/</span>
     🏓 Ping Pong
   </div>
@@ -129,7 +132,7 @@
     <button class="btn btn-ghost" id="pauseBtn">⏸ Pause</button>
     <button class="btn btn-ghost" id="howToPlayBtn">❓ How to Play</button>
     <button class="btn btn-ghost" id="restartBtn">↺ Restart</button>
-    <button class="btn btn-ghost" id="exitBtn">🏠 Home</button>
+    <button class="btn btn-danger" id="exitBtn">✕ EXIT</button>
   </div>
 </div>
 
@@ -189,7 +192,7 @@
     <p id="resultSubtitle">Amazing performance!</p>
     <div class="modal-btns">
       <button class="btn btn-primary" id="playAgainBtn">▶ Play Again</button>
-      <button class="btn btn-ghost" id="resultExitBtn">🏠 Home</button>
+      <button class="btn btn-danger" id="resultExitBtn">✕ EXIT</button>
     </div>
   </div>
 </div>
@@ -758,8 +761,8 @@ document.getElementById('playAgainBtn').addEventListener('click', () => {
   initGame();
 });
 
-document.getElementById('exitBtn').addEventListener('click', () => window.location.href = '../../index.html');
-document.getElementById('resultExitBtn').addEventListener('click', () => window.location.href = '../../index.html');
+document.getElementById('exitBtn').addEventListener('click', () => window.location.href = '/');
+document.getElementById('resultExitBtn').addEventListener('click', () => window.location.href = '/');
 
 // ── Sound toggle
 document.getElementById('soundBtn').addEventListener('click', () => {
@@ -778,6 +781,13 @@ document.getElementById('soundBtn').addEventListener('click', () => {
   aiY     = CH / 2 - PADDLE_H / 2;
   draw();
 })();
+</script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+<script src="../shared/firebase.js"></script>
+<script>
+SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
 </script>
 </body>
 </html>

--- a/games/shared/firebase.js
+++ b/games/shared/firebase.js
@@ -34,6 +34,7 @@ const SillyFirebase = {
     try {
       await this._ref(this.currentUser.uid, gameId).set({
         ...data,
+        uid: this.currentUser.uid,
         email: this.currentUser.email
       });
     } catch(e) { console.warn('[SillyFirebase] save failed', e); }
@@ -58,9 +59,16 @@ const SillyFirebase = {
 
     if (!cloud && !local) return;
     if (!cloud && local)  { await this.saveProgress(gameId, local); return; }
-    if (cloud && !local)  { localStorage.setItem(localKey, JSON.stringify(cloud)); return; }
+    // Cloud exists — stamp it with uid when writing to localStorage
+    if (cloud && !local)  { localStorage.setItem(localKey, JSON.stringify({...cloud, uid: this.currentUser.uid})); return; }
 
-    // Both exist — use whichever has the newer savedAt timestamp
+    // Both exist — if local has no uid or belongs to a different user, it's guest data; prefer cloud
+    if (!local.uid || local.uid !== this.currentUser.uid) {
+      localStorage.setItem(localKey, JSON.stringify({...cloud, uid: this.currentUser.uid}));
+      return;
+    }
+
+    // Both belong to the same authenticated user — use whichever has the newer savedAt timestamp
     if ((cloud.savedAt || 0) > (local.savedAt || 0)) {
       localStorage.setItem(localKey, JSON.stringify(cloud));
     } else {
@@ -108,5 +116,51 @@ const SillyFirebase = {
     } else {
       bar.innerHTML = `<button class="gbtn google-btn" onclick="${signInFnName}" style="width:100%">Google Sign In</button>`;
     }
+  },
+
+  // ─── Avatar indicator ────────────────────────────────────────
+
+  // Generate a consistent HSL color from a string (display name or email).
+  avatarColor(str) {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) hash = str.charCodeAt(i) + ((hash << 5) - hash);
+    return `hsl(${Math.abs(hash) % 360}, 65%, 48%)`;
+  },
+
+  // Render a read-only avatar circle (initial letter) into an element.
+  // Shows when signed in, clears when signed out.
+  renderAvatar(elementId, user) {
+    const el = document.getElementById(elementId);
+    if (!el) return;
+    if (user) {
+      const name = user.displayName || user.email || '?';
+      const initial = name.charAt(0).toUpperCase();
+      const color = this.avatarColor(name);
+      el.innerHTML = `<div style="
+        width:36px;height:36px;border-radius:50%;
+        background:${color};color:#fff;
+        font-size:16px;font-weight:700;font-family:sans-serif;
+        display:flex;align-items:center;justify-content:center;
+        box-shadow:0 2px 6px rgba(0,0,0,0.3);
+        user-select:none;">${initial}</div>`;
+    } else {
+      el.innerHTML = '';
+    }
+  },
+
+  // ─── Visit tracking ──────────────────────────────────────────
+
+  // Increment visit counter for pageId and return the new total.
+  // Stored at analytics/{pageId} → { total: N }
+  async trackVisit(pageId) {
+    try {
+      const ref = _sfDb.collection('analytics').doc(pageId);
+      await ref.set(
+        { total: firebase.firestore.FieldValue.increment(1) },
+        { merge: true }
+      );
+      const snap = await ref.get();
+      return snap.exists ? (snap.data().total || 0) : 0;
+    } catch(e) { console.warn('[SillyFirebase] trackVisit failed', e); return null; }
   }
 };

--- a/index.html
+++ b/index.html
@@ -217,6 +217,77 @@
     }
     .game-card:hover .play-btn { opacity: 0.9; transform: scale(1.03); }
 
+    /* ── AUTH BAR ── */
+    #lobby-auth-bar {
+      flex-shrink: 0;
+      width: 160px;
+      display: flex;
+      align-items: center;
+    }
+    #lobby-auth-bar { position: relative; }
+    #lobby-auth-bar .lobby-sign-in-btn {
+      background: linear-gradient(135deg, var(--accent), #5b21b6);
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      padding: 0.45rem 1rem;
+      font-size: 0.82rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: opacity 0.2s;
+      white-space: nowrap;
+    }
+    #lobby-auth-bar .lobby-sign-in-btn:hover { opacity: 0.85; }
+    .lobby-avatar-btn {
+      width: 38px; height: 38px;
+      border-radius: 50%;
+      border: none;
+      cursor: pointer;
+      font-size: 17px;
+      font-weight: 700;
+      color: #fff;
+      font-family: sans-serif;
+      display: flex; align-items: center; justify-content: center;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.35);
+      transition: opacity 0.15s;
+      flex-shrink: 0;
+    }
+    .lobby-avatar-btn:hover { opacity: 0.85; }
+    .lobby-avatar-popup {
+      position: absolute;
+      top: 48px; right: 0;
+      background: #1e1e3a;
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 1rem 1.1rem 0.85rem;
+      min-width: 220px;
+      z-index: 200;
+      box-shadow: 0 8px 28px rgba(0,0,0,0.45);
+    }
+    .lobby-avatar-popup .popup-name {
+      font-weight: 700;
+      font-size: 0.92rem;
+      margin-bottom: 0.2rem;
+      color: var(--text);
+    }
+    .lobby-avatar-popup .popup-email {
+      font-size: 0.78rem;
+      color: var(--muted);
+      margin-bottom: 0.9rem;
+    }
+    .lobby-avatar-popup .lobby-sign-out-btn {
+      width: 100%;
+      background: transparent;
+      border: 1px solid var(--border);
+      color: var(--muted);
+      border-radius: 8px;
+      padding: 0.35rem 0.75rem;
+      font-size: 0.78rem;
+      cursor: pointer;
+      transition: border-color 0.2s, color 0.2s;
+    }
+    .lobby-avatar-popup .lobby-sign-out-btn:hover { border-color: var(--accent); color: var(--text); }
+
     /* ── FOOTER ── */
     footer {
       border-top: 1px solid var(--border);
@@ -244,6 +315,8 @@
       <a href="#">Top</a>
       <a href="#">Categories</a>
     </nav>
+    <div id="visit-counter" style="font-size:0.78rem;color:var(--muted);white-space:nowrap;"></div>
+    <div id="lobby-auth-bar"></div>
   </div>
 </header>
 
@@ -261,7 +334,7 @@
   <div class="games-grid">
 
     <!-- ── Blocks Classic ── -->
-    <a class="game-card" href="games/blocks-classic/index.html" target="_blank" rel="noopener">
+    <a class="game-card" href="games/blocks-classic/">
       <div class="card-thumb">
         <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
           <defs>
@@ -331,7 +404,7 @@
     </a>
 
     <!-- ── Bubble Shooter ── -->
-    <a class="game-card" href="games/bubble-shooter/index.html" target="_blank" rel="noopener">
+    <a class="game-card" href="games/bubble-shooter/">
       <div class="card-thumb">
         <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
           <defs>
@@ -432,7 +505,7 @@
     </a>
 
     <!-- ── Count Masters ── -->
-    <a class="game-card" href="games/count-masters/index.html" target="_blank" rel="noopener">
+    <a class="game-card" href="games/count-masters/">
       <div class="card-thumb">
         <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
           <defs>
@@ -540,7 +613,7 @@
     </a>
 
     <!-- ── Ping Pong ── -->
-    <a class="game-card" href="games/ping-pong/index.html" target="_blank" rel="noopener">
+    <a class="game-card" href="games/ping-pong/">
       <div class="card-thumb">
         <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
           <defs>
@@ -593,7 +666,7 @@
     </a>
 
     <!-- ── Bounce Rush ── -->
-    <a class="game-card" href="games/bounce-rush/index.html" target="_blank" rel="noopener">
+    <a class="game-card" href="games/bounce-rush/">
       <div class="card-thumb">
         <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
           <defs>
@@ -665,7 +738,7 @@
     </a>
 
     <!-- ── Bubble Bobble ── -->
-    <a class="game-card" href="games/bubble-bobble/index.html" target="_blank" rel="noopener">
+    <a class="game-card" href="games/bubble-bobble/">
       <div class="card-thumb">
         <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
           <defs>
@@ -727,7 +800,7 @@
       </div>
     </a>
 
-    <a class="game-card" href="games/pac-man/index.html" target="_blank" rel="noopener">
+    <a class="game-card" href="games/pac-man/">
       <div class="card-thumb">
         <svg viewBox="0 0 320 180" xmlns="http://www.w3.org/2000/svg">
           <defs>
@@ -823,5 +896,59 @@
   &copy; 2026 GameZone &mdash; Free browser games, no download required.
 </footer>
 
+
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
+<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
+<script src="games/shared/firebase.js"></script>
+<script>
+  function lobbyRenderAuthBar(user) {
+    const bar = document.getElementById('lobby-auth-bar');
+    if (!bar) return;
+    if (user) {
+      const name = user.displayName || user.email || '?';
+      const initial = name.charAt(0).toUpperCase();
+      const color = SillyFirebase.avatarColor(name);
+      bar.innerHTML = `
+        <button class="lobby-avatar-btn" id="lobby-avatar-btn"
+                style="background:${color}" onclick="lobbyTogglePopup()">
+          ${initial}
+        </button>
+        <div class="lobby-avatar-popup" id="lobby-avatar-popup" style="display:none">
+          <div class="popup-name">Hi, ${name}!</div>
+          <div class="popup-email">${user.email}</div>
+          <button class="lobby-sign-out-btn" onclick="SillyFirebase.signOut()">Sign Out</button>
+        </div>`;
+    } else {
+      bar.innerHTML = `<button class="lobby-sign-in-btn" onclick="SillyFirebase.signIn()">Google Sign In</button>`;
+    }
+  }
+
+  function lobbyTogglePopup() {
+    const popup = document.getElementById('lobby-avatar-popup');
+    if (!popup) return;
+    popup.style.display = popup.style.display === 'none' ? 'block' : 'none';
+  }
+
+  document.addEventListener('click', e => {
+    const btn = document.getElementById('lobby-avatar-btn');
+    const popup = document.getElementById('lobby-avatar-popup');
+    if (!popup || popup.style.display === 'none') return;
+    if (btn && btn.contains(e.target)) return;
+    if (!popup.contains(e.target)) popup.style.display = 'none';
+  });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    SillyFirebase.onAuthChanged(user => {
+      lobbyRenderAuthBar(user);
+      if (user) {
+        SillyFirebase.trackVisit('lobby').then(total => {
+          const el = document.getElementById('visit-counter');
+          if (el && total !== null) el.textContent = total.toLocaleString() + ' total visits';
+        });
+      }
+    });
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- **Lobby auth** — Google Sign-In with avatar circle + popup (name, email, sign-out). Fixes #56, #58, #60
- **Platform-level auth** — removed per-game sign-in UI; all games show a read-only avatar indicator (top-right). Fixes #57, #59
- **Unified EXIT button** — red ✕ EXIT button across all 7 games, navigates to lobby. Fixes #62, #66
- **Bubble Bobble save/resume** — progress saved on EXIT; uid-stamped saves prevent guest contamination on re-sign-in. Fixes #61, #64
- **Pac-Man save/resume** — level saved on EXIT; Continue / New Game menu on title screen. Fixes #65
- **shared/firebase.js** — added `avatarColor()`, `renderAvatar()`, `trackVisit()`, uid-stamped `syncProgress()`
- **Lobby visit counter** — increments and displays for signed-in users. Refs #55 (in progress)

## Test plan

- [ ] Sign in from lobby — avatar appears, popup works, sign-out works
- [ ] Open each game — avatar indicator visible top-right
- [ ] Click EXIT in each game — returns to lobby in same tab
- [ ] Bubble Bobble: play to level 2 → EXIT → re-enter → resumes from level 2
- [ ] Pac-Man: play levels → EXIT → re-enter → Continue/New Game menu appears
- [ ] Sign out → re-enter Bubble Bobble as guest → starts from level 1 (not signed-in save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)