### PR TITLE
fix/bugs: auth simplification, Blocks Classic save, Bounce Rush progression

### DIFF
--- a/games/blocks-classic/index.html
+++ b/games/blocks-classic/index.html
@@ -78,6 +78,10 @@
       background: linear-gradient(135deg, #dc2626, #991b1b);
       color: #fff;
     }
+    .btn-secondary {
+      background: linear-gradient(135deg, #1e4d8c, #1a3a6b);
+      color: #fff;
+    }
 
     /* ── GAME AREA ── */
     .game-wrapper {
@@ -331,7 +335,8 @@
       Fill complete horizontal lines to clear them and score points.<br>
       Speed increases every 10 lines. Don't let blocks reach the top!
     </p>
-    <div class="modal-buttons">
+    <div class="modal-buttons" style="display:flex;gap:0.6rem;flex-wrap:wrap;justify-content:center;">
+      <button class="btn btn-secondary" id="continueBtn" style="display:none;min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">▶ Continue</button>
       <button class="btn btn-primary" id="startBtn" style="min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
     </div>
   </div>
@@ -455,6 +460,7 @@ function playGameOver() {
 // ─────────────────────────────────────────────
 let board, currentPiece, currentX, currentY, nextPiece;
 let score, level, lines, gameRunning, paused, dropTimer, dropInterval;
+let gamePlayedAs = null; // uid of user who started the current game, null for guest
 let screenFlash = { timer: 0, r: 255, g: 255, b: 255 };
 let comboDisplay  = { text: '', timer: 0 };
 
@@ -508,9 +514,11 @@ function clearLines() {
     }
   }
   if (cleared) {
+    const prevLevel = level;
     score += SCORE_TABLE[cleared] * level;
     lines += cleared;
     level = Math.min(10, Math.floor(lines / 10) + 1);
+    if (level > prevLevel) saveProgress();
     playLineClear(cleared);
     // Screen flash colour & combo label
     const flashPalette = [[80,220,255],[180,100,255],[255,160,40],[255,215,0]];
@@ -567,9 +575,82 @@ function tick() {
   draw();
 }
 
-function initGame() {
+// ─────────────────────────────────────────────
+//  SAVE / LOAD PROGRESS
+// ─────────────────────────────────────────────
+const BC_SAVE_KEY   = 'blocksClassic_save';       // signed-in user: localStorage
+const BC_GUEST_KEY  = 'blocksClassic_guest_save';  // guest only: sessionStorage
+
+// savedState: { score, level, lines } or null
+// Guest: sessionStorage under BC_GUEST_KEY (separate from signed-in key — no collision)
+// Signed-in: localStorage under BC_SAVE_KEY + per-user key + Firestore
+let savedState = (() => {
+  try {
+    const local = JSON.parse(localStorage.getItem(BC_SAVE_KEY));
+    if (local && local.uid) return local;
+    const sess = JSON.parse(sessionStorage.getItem(BC_GUEST_KEY));
+    return sess || null;
+  } catch(e) { return null; }
+})();
+
+function saveProgress() {
+  const uid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser)
+              ? SillyFirebase.currentUser.uid : null;
+  const data = { score, level, lines, savedAt: Date.now(), ...(uid ? { uid } : {}) };
+  if (uid) {
+    localStorage.setItem(BC_SAVE_KEY, JSON.stringify(data));
+    localStorage.setItem(`blocksClassic_save_${uid}`, JSON.stringify(data));
+    if (typeof SillyFirebase !== 'undefined') SillyFirebase.saveProgress('blocksClassic', data);
+  } else {
+    sessionStorage.setItem(BC_GUEST_KEY, JSON.stringify(data));
+  }
+  savedState = data;
+}
+
+function clearSaveProgress() {
+  savedState = null;
+  localStorage.removeItem(BC_SAVE_KEY);
+  // Only clear the save that belongs to whoever started this game
+  if (gamePlayedAs) {
+    // Signed-in user's game — clear their keys; leave guest session untouched
+    localStorage.removeItem(`blocksClassic_save_${gamePlayedAs}`);
+    if (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser?.uid === gamePlayedAs) {
+      SillyFirebase.saveProgress('blocksClassic', { score: 0, level: 1, lines: 0, savedAt: Date.now() });
+    }
+  } else {
+    // Guest's game — clear guest session key
+    sessionStorage.removeItem(BC_GUEST_KEY);
+  }
+}
+
+function updateStartOverlay() {
+  const continueBtn = document.getElementById('continueBtn');
+  const startBtn    = document.getElementById('startBtn');
+  if (gameRunning) {
+    continueBtn.style.display = 'none';
+    startBtn.textContent = '▶ Resume Game';
+  } else if (savedState && savedState.level > 1) {
+    continueBtn.style.display = '';
+    continueBtn.textContent   = `▶ Continue (Level ${savedState.level})`;
+    startBtn.textContent = '▶ New Game';
+  } else {
+    continueBtn.style.display = 'none';
+    startBtn.textContent = '▶ Start Game';
+  }
+}
+
+function initGame(fromSave = false) {
   board = Array.from({ length: ROWS }, () => new Array(COLS).fill(0));
-  score = 0; level = 1; lines = 0;
+  gamePlayedAs = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser)
+                  ? SillyFirebase.currentUser.uid : null;
+  if (fromSave && savedState) {
+    score = savedState.score || 0;
+    level = savedState.level || 1;
+    lines = savedState.lines || 0;
+  } else {
+    score = 0; level = 1; lines = 0;
+    clearSaveProgress();
+  }
   nextPiece = randomPiece();
   spawnPiece();
   gameRunning = true;
@@ -582,6 +663,16 @@ function initGame() {
 function endGame() {
   gameRunning = false;
   clearInterval(dropInterval);
+  clearSaveProgress();
+  // If a signed-in user's save exists and they didn't play this game, restore it
+  const uid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser)
+              ? SillyFirebase.currentUser.uid : null;
+  if (uid && uid !== gamePlayedAs) {
+    try {
+      const s = JSON.parse(localStorage.getItem(`blocksClassic_save_${uid}`));
+      if (s && s.uid === uid) savedState = s;
+    } catch(e) {}
+  }
   playGameOver();
   document.getElementById('finalScore').textContent = score.toLocaleString();
   document.getElementById('finalLevel').textContent = level;
@@ -774,29 +865,36 @@ document.getElementById('restartBtn').addEventListener('click', () => {
   document.getElementById('gameOverOverlay').classList.remove('active');
   document.getElementById('pauseBadge').classList.remove('visible');
   document.getElementById('pauseBtn').textContent = '⏸ Pause';
-  initGame();
+  initGame(false);
 });
 document.getElementById('exitBtn').addEventListener('click', () => {
+  if (gameRunning) saveProgress();
   window.location.href = '../../';
 });
 document.getElementById('gameOverRestartBtn').addEventListener('click', () => {
   document.getElementById('gameOverOverlay').classList.remove('active');
   document.getElementById('pauseBadge').classList.remove('visible');
   document.getElementById('pauseBtn').textContent = '⏸ Pause';
-  initGame();
+  initGame(false);
 });
 document.getElementById('gameOverExitBtn').addEventListener('click', () => {
   window.location.href = '../../';
 });
 document.getElementById('howToPlayBtn').addEventListener('click', () => {
   if (gameRunning && !paused) togglePause();
-  document.getElementById('startBtn').textContent = gameRunning ? '▶ Resume Game' : '▶ Start Game';
+  updateStartOverlay();
   document.getElementById('startOverlay').classList.add('active');
+});
+document.getElementById('continueBtn').addEventListener('click', () => {
+  document.getElementById('startOverlay').classList.remove('active');
+  document.getElementById('pauseBadge').classList.remove('visible');
+  document.getElementById('pauseBtn').textContent = '⏸ Pause';
+  initGame(true);
 });
 document.getElementById('startBtn').addEventListener('click', () => {
   document.getElementById('startOverlay').classList.remove('active');
   if (!gameRunning) {
-    initGame();
+    initGame(false);
   } else if (paused) {
     togglePause();
   }
@@ -809,14 +907,51 @@ currentPiece = randomPiece();
 currentX = 3; currentY = 0;
 score = 0; level = 1; lines = 0;
 draw();
+updateStartOverlay();
 </script>
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-auth-compat.js"></script>
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
-SillyFirebase.renderAvatarFromCache('game-avatar');
-SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
+// Pre-load savedState from per-user localStorage before async auth resolves
+(() => {
+  try {
+    const cached = JSON.parse(localStorage.getItem('_sfAvatarCache'));
+    if (cached && cached.uid) {
+      const local = JSON.parse(localStorage.getItem(`blocksClassic_save_${cached.uid}`));
+      if (local && local.uid === cached.uid) {
+        savedState = local;
+        updateStartOverlay();
+      }
+    }
+  } catch(e) {}
+})();
+
+SillyFirebase.renderAvatarFromCacheDisplay('game-avatar');
+SillyFirebase.onAuthChanged(async user => {
+  SillyFirebase.renderAvatarDisplay('game-avatar', user);
+  if (user) {
+    const localKey = `blocksClassic_save_${user.uid}`;
+    let local = null;
+    try { local = JSON.parse(localStorage.getItem(localKey)); } catch(e) {}
+    if (local && local.uid === user.uid) {
+      savedState = local;
+    } else {
+      await SillyFirebase.syncProgress('blocksClassic', localKey);
+      try { savedState = JSON.parse(localStorage.getItem(localKey)); } catch(e) {}
+    }
+    if (!gameRunning) updateStartOverlay();
+  } else {
+    savedState = null;
+    localStorage.removeItem(BC_SAVE_KEY);
+    try {
+      const sess = JSON.parse(sessionStorage.getItem(BC_GUEST_KEY));
+      if (sess) savedState = sess;
+    } catch(e) {}
+    if (!gameRunning) updateStartOverlay();
+  }
+});
 </script>
 </body>
 </html>

--- a/games/blocks-classic/index.html
+++ b/games/blocks-classic/index.html
@@ -815,6 +815,7 @@ draw();
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
+SillyFirebase.renderAvatarFromCache('game-avatar');
 SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
 </script>
 </body>

--- a/games/bounce-rush/index.html
+++ b/games/bounce-rush/index.html
@@ -1077,8 +1077,9 @@ openModal(false);
   } catch(e) {}
 })();
 
-SillyFirebase.renderAvatarFromCache('game-avatar');
+SillyFirebase.renderAvatarFromCacheDisplay('game-avatar');
 SillyFirebase.onAuthChanged(async user => {
+  SillyFirebase.renderAvatarDisplay('game-avatar', user);
   if (user) {
     const userSaveKey = `bounceRush_save_${user.uid}`;
     const cloud = await SillyFirebase.loadProgress('bounceRush');
@@ -1099,18 +1100,16 @@ SillyFirebase.onAuthChanged(async user => {
         await SillyFirebase.saveProgress('bounceRush', userLocal);
       }
     }
-    // Refresh modal if still on title screen
     if (gameState === 'idle') openModal(false);
   } else {
-    // Guest: clear signed-in save, use sessionStorage
-    const local = JSON.parse(localStorage.getItem(BR_SAVE_KEY) || 'null');
-    if (local && local.uid) {
-      localStorage.removeItem(BR_SAVE_KEY);
-      savedLevel = 0;
-    }
+    localStorage.removeItem(BR_SAVE_KEY);
+    savedLevel = 0;
+    try {
+      const sess = JSON.parse(sessionStorage.getItem(BR_SAVE_KEY) || 'null');
+      if (sess && !sess.uid) savedLevel = sess.currentLevel || 0;
+    } catch(e) {}
     if (gameState === 'idle') openModal(false);
   }
-  SillyFirebase.renderAvatar('game-avatar', user);
 });
 </script>
 </body>

--- a/games/bounce-rush/index.html
+++ b/games/bounce-rush/index.html
@@ -1015,6 +1015,7 @@ openModal(false);
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
+SillyFirebase.renderAvatarFromCache('game-avatar');
 SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
 </script>
 </body>

--- a/games/bounce-rush/index.html
+++ b/games/bounce-rush/index.html
@@ -99,19 +99,13 @@
     cursor: pointer; transition: opacity 0.2s;
   }
   .modal-start:hover { opacity: 0.85; }
-  .level-grid {
-    display: grid; grid-template-columns: repeat(4, 1fr); gap: 0.4rem;
-    margin: 0.5rem 0 0.9rem;
+  .modal-continue {
+    flex: 1; background: linear-gradient(135deg, #0891b2, #0e7490);
+    border: none; color: #fff; border-radius: 9px;
+    padding: 0.65rem; font-size: 0.95rem; font-weight: 700;
+    cursor: pointer; transition: opacity 0.2s;
   }
-  .lvl-btn {
-    background: #14142b; border: 1px solid #2a2a50;
-    border-radius: 7px; padding: 0.35rem 0.1rem;
-    font-size: 0.8rem; font-weight: 600; color: #94a3b8;
-    cursor: pointer; transition: all 0.15s; text-align: center;
-  }
-  .lvl-btn:hover  { background: #22224a; color: #e2e8f0; }
-  .lvl-btn.active { background: #7c3aed; border-color: #a78bfa; color: #fff; }
-  .lvl-btn.done   { border-color: #22c55e; color: #4ade80; }
+  .modal-continue:hover { opacity: 0.85; }
   #game-avatar{display:flex;align-items:center;margin-left:0.5rem;}
 </style>
 </head>
@@ -145,7 +139,7 @@
   <canvas id="c" width="460" height="540"></canvas>
 </div>
 
-<!-- Instructions / Level Select Modal -->
+<!-- Instructions / Title Modal -->
 <div class="modal-overlay" id="modalOverlay">
   <div class="modal">
     <h2>🟡 Bounce Rush</h2>
@@ -157,9 +151,8 @@
       <li>Fewer boosts = more stars</li>
     </ul>
     <p style="color:#64748b; font-size:0.78rem;">Tip: Click near the ball for a gentle redirect, far away for full power.</p>
-    <p style="margin-top:0.4rem; color:#e2e8f0; font-size:0.82rem; font-weight:600;">Select Level</p>
-    <div class="level-grid" id="levelGrid"></div>
-    <div class="modal-btns">
+    <div class="modal-btns" id="modalBtns">
+      <button class="modal-continue" id="modalContinueBtn" style="display:none">▶ Continue</button>
       <button class="modal-start" id="modalStartBtn">▶ Start Game</button>
     </div>
   </div>
@@ -339,6 +332,41 @@ let gameState  = 'idle';   // idle | playing | win
 let savedState = null;
 
 let currentLevel = 0;
+const BR_SAVE_KEY = 'bounceRush_save';
+
+// savedLevel: index of level to resume from (0 = first level)
+// Guest: sessionStorage (clears on browser close)
+// Signed-in: localStorage + Firestore
+let savedLevel = (() => {
+  try {
+    const local = JSON.parse(localStorage.getItem(BR_SAVE_KEY));
+    if (local && local.uid) return local.currentLevel || 0;
+    const sess = JSON.parse(sessionStorage.getItem(BR_SAVE_KEY));
+    return sess ? (sess.currentLevel || 0) : 0;
+  } catch(e) { return 0; }
+})();
+
+function saveProgress() {
+  const uid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser)
+              ? SillyFirebase.currentUser.uid : null;
+  const data = { currentLevel: savedLevel, savedAt: Date.now(), ...(uid ? { uid } : {}) };
+  if (uid) {
+    localStorage.setItem(BR_SAVE_KEY, JSON.stringify(data));
+    localStorage.setItem(`bounceRush_save_${uid}`, JSON.stringify(data));
+    if (typeof SillyFirebase !== 'undefined') SillyFirebase.saveProgress('bounceRush', data);
+  } else {
+    sessionStorage.setItem(BR_SAVE_KEY, JSON.stringify(data));
+  }
+}
+
+function clearSaveProgress() {
+  savedLevel = 0;
+  localStorage.removeItem(BR_SAVE_KEY);
+  sessionStorage.removeItem(BR_SAVE_KEY);
+  if (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser)
+    SillyFirebase.saveProgress('bounceRush', { currentLevel: 0, savedAt: Date.now() });
+}
+
 let levelDone    = new Array(LEVELS.length).fill(false);
 let levelStars   = new Array(LEVELS.length).fill(0);
 
@@ -930,8 +958,12 @@ canvas.addEventListener('click', e => {
     const bx = CW/2 - 82, by = CH/2 + 40;
     if (pos.x >= bx && pos.x <= bx+164 && pos.y >= by && pos.y <= by+44) {
       if (currentLevel < LEVELS.length - 1) {
-        loadLevel(currentLevel + 1);
+        savedLevel = currentLevel + 1;
+        saveProgress();
+        loadLevel(savedLevel);
         startMusic();
+      } else {
+        clearSaveProgress();
       }
     }
     return;
@@ -947,7 +979,14 @@ canvas.addEventListener('touchstart', e => {
   if (gameState === 'win') {
     const bx = CW/2 - 82, by = CH/2 + 40;
     if (pos.x >= bx && pos.x <= bx+164 && pos.y >= by && pos.y <= by+44) {
-      if (currentLevel < LEVELS.length - 1) { loadLevel(currentLevel + 1); startMusic(); }
+      if (currentLevel < LEVELS.length - 1) {
+        savedLevel = currentLevel + 1;
+        saveProgress();
+        loadLevel(savedLevel);
+        startMusic();
+      } else {
+        clearSaveProgress();
+      }
     }
     return;
   }
@@ -956,31 +995,42 @@ canvas.addEventListener('touchstart', e => {
 }, {passive: false});
 
 // ═══════════════════════════════════════════════════════
-//  MODAL + BUTTONS
+//  MODAL (Title / How-to-Play)
 // ═══════════════════════════════════════════════════════
-function buildLevelGrid() {
-  const grid = document.getElementById('levelGrid');
-  grid.innerHTML = '';
-  for (let i = 0; i < LEVELS.length; i++) {
-    const btn = document.createElement('button');
-    btn.className = 'lvl-btn' +
-      (i === currentLevel ? ' active' : '') +
-      (levelDone[i] ? ' done' : '');
-    btn.textContent = i + 1;
-    btn.title = LEVELS[i].name;
-    btn.addEventListener('click', () => {
-      document.querySelectorAll('.lvl-btn').forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
-      currentLevel = i;
-    });
-    grid.appendChild(btn);
-  }
-}
-
 function openModal(isResume) {
-  buildLevelGrid();
-  document.getElementById('modalStartBtn').textContent =
-    isResume ? '▶ Resume Game' : '▶ Start Game';
+  const continueBtn = document.getElementById('modalContinueBtn');
+  const startBtn    = document.getElementById('modalStartBtn');
+
+  if (isResume) {
+    // Opened via How to Play during gameplay
+    continueBtn.style.display = 'none';
+    startBtn.textContent = '▶ Resume Game';
+    startBtn.onclick = closeModal;
+  } else {
+    // Title screen
+    if (savedLevel > 0) {
+      continueBtn.style.display = '';
+      continueBtn.textContent = `▶ Continue (Level ${savedLevel + 1})`;
+      continueBtn.onclick = () => {
+        document.getElementById('modalOverlay').classList.add('hidden');
+        loadLevel(savedLevel);
+        startMusic();
+      };
+      startBtn.textContent = '▶ New Game';
+      startBtn.onclick = () => {
+        savedLevel = 0;
+        clearSaveProgress();
+        document.getElementById('modalOverlay').classList.add('hidden');
+        loadLevel(0);
+        startMusic();
+      };
+    } else {
+      continueBtn.style.display = 'none';
+      startBtn.textContent = '▶ Start Game';
+      startBtn.onclick = closeModal;
+    }
+  }
+
   document.getElementById('modalOverlay').classList.remove('hidden');
   savedState = gameState;
   gameState = 'idle';
@@ -989,7 +1039,7 @@ function openModal(isResume) {
 function closeModal() {
   document.getElementById('modalOverlay').classList.add('hidden');
   if (savedState === 'idle' || savedState === null) {
-    loadLevel(currentLevel);
+    loadLevel(savedLevel);
   } else {
     gameState = savedState;
   }
@@ -1000,14 +1050,13 @@ function closeModal() {
 document.getElementById('howBtn').addEventListener('click', () => {
   openModal(gameState !== 'idle');
 });
-document.getElementById('modalStartBtn').addEventListener('click', closeModal);
 
 document.getElementById('restartBtn').addEventListener('click', () => {
   loadLevel(currentLevel);
   startMusic();
 });
 
-// Launch with modal
+// Launch with title modal
 openModal(false);
 </script>
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
@@ -1015,8 +1064,54 @@ openModal(false);
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
+// Pre-load savedLevel from cached uid
+(function() {
+  try {
+    const cached = JSON.parse(localStorage.getItem(SillyFirebase._AVATAR_CACHE_KEY));
+    if (cached && cached.uid) {
+      const userSave = JSON.parse(localStorage.getItem(`bounceRush_save_${cached.uid}`));
+      if (userSave && userSave.currentLevel > 0) {
+        savedLevel = userSave.currentLevel;
+      }
+    }
+  } catch(e) {}
+})();
+
 SillyFirebase.renderAvatarFromCache('game-avatar');
-SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
+SillyFirebase.onAuthChanged(async user => {
+  if (user) {
+    const userSaveKey = `bounceRush_save_${user.uid}`;
+    const cloud = await SillyFirebase.loadProgress('bounceRush');
+    let userLocal = null;
+    try { userLocal = JSON.parse(localStorage.getItem(userSaveKey)); } catch(e) {}
+
+    let best = null;
+    if (cloud && userLocal) {
+      best = (cloud.savedAt || 0) >= (userLocal.savedAt || 0) ? cloud : userLocal;
+    } else {
+      best = cloud || userLocal;
+    }
+    if (best) {
+      savedLevel = best.currentLevel || 0;
+      localStorage.setItem(BR_SAVE_KEY, JSON.stringify(best));
+      localStorage.setItem(userSaveKey, JSON.stringify(best));
+      if (userLocal && (!cloud || (userLocal.savedAt || 0) > (cloud.savedAt || 0))) {
+        await SillyFirebase.saveProgress('bounceRush', userLocal);
+      }
+    }
+    // Refresh modal if still on title screen
+    if (gameState === 'idle') openModal(false);
+  } else {
+    // Guest: clear signed-in save, use sessionStorage
+    const local = JSON.parse(localStorage.getItem(BR_SAVE_KEY) || 'null');
+    if (local && local.uid) {
+      localStorage.removeItem(BR_SAVE_KEY);
+      savedLevel = 0;
+    }
+    if (gameState === 'idle') openModal(false);
+  }
+  SillyFirebase.renderAvatar('game-avatar', user);
+});
 </script>
 </body>
 </html>

--- a/games/bubble-bobble/index.html
+++ b/games/bubble-bobble/index.html
@@ -1360,18 +1360,12 @@ updateHUD();
 <script src="../shared/firebase.js"></script>
 <script>
 // ─── Bubble Bobble Firebase wiring ───────────────────────────
-SillyFirebase.renderAvatarFromCache('game-avatar');
-let _bbAuthReady = false;
+SillyFirebase.renderAvatarFromCacheDisplay('game-avatar');
 SillyFirebase.onAuthChanged(async user => {
+  SillyFirebase.renderAvatarDisplay('game-avatar', user);
   if (user) {
-    _bbAuthReady = true;
     await SillyFirebase.syncProgress('bubbleBobble', SAVE_KEY);
-  } else if (_bbAuthReady) {
-    // Real sign-out (not the initial null flash on page load)
-    clearSave();
   }
-  _bbAuthReady = true;
-  SillyFirebase.renderAvatar('game-avatar', user);
 });
 </script>
 </body>

--- a/games/bubble-bobble/index.html
+++ b/games/bubble-bobble/index.html
@@ -1360,6 +1360,7 @@ updateHUD();
 <script src="../shared/firebase.js"></script>
 <script>
 // ─── Bubble Bobble Firebase wiring ───────────────────────────
+SillyFirebase.renderAvatarFromCache('game-avatar');
 let _bbAuthReady = false;
 SillyFirebase.onAuthChanged(async user => {
   if (user) {

--- a/games/bubble-shooter/index.html
+++ b/games/bubble-shooter/index.html
@@ -1018,8 +1018,8 @@ drawNextBubble();
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
-SillyFirebase.renderAvatarFromCache('game-avatar');
-SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
+SillyFirebase.renderAvatarFromCacheDisplay('game-avatar');
+SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatarDisplay('game-avatar', user));
 </script>
 </body>
 </html>

--- a/games/bubble-shooter/index.html
+++ b/games/bubble-shooter/index.html
@@ -1018,6 +1018,7 @@ drawNextBubble();
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
+SillyFirebase.renderAvatarFromCache('game-avatar');
 SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
 </script>
 </body>

--- a/games/count-masters/index.html
+++ b/games/count-masters/index.html
@@ -1385,8 +1385,8 @@ document.getElementById('resultExitBtn').addEventListener('click', () => { windo
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
-SillyFirebase.renderAvatarFromCache('game-avatar');
-SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
+SillyFirebase.renderAvatarFromCacheDisplay('game-avatar');
+SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatarDisplay('game-avatar', user));
 </script>
 </body>
 </html>

--- a/games/count-masters/index.html
+++ b/games/count-masters/index.html
@@ -1385,6 +1385,7 @@ document.getElementById('resultExitBtn').addEventListener('click', () => { windo
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
+SillyFirebase.renderAvatarFromCache('game-avatar');
 SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
 </script>
 </body>

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -1716,7 +1716,7 @@ document.getElementById('pac-exit-btn').addEventListener('click', () => {
   window.location.href = '../../';
 });
 
-SillyFirebase.renderAvatarFromCache('game-avatar');
+SillyFirebase.renderAvatarFromCacheDisplay('game-avatar');
 
 // Pre-load savedLevel from user-specific localStorage using cached uid —
 // eliminates the title screen pop-in delay before onAuthChanged resolves.
@@ -1776,9 +1776,7 @@ SillyFirebase.onAuthChanged(async user => {
   }
   // Re-draw title screen if game hasn't started yet
   if (!gameRunning) { drawMaze(); drawPac(); drawTray(); drawSoundIcon(); drawStartPrompt(); }
-  SillyFirebase.renderAvatar('game-avatar', user, () => {
-    if (gameRunning && !paused && !gameOver && !youWin) togglePause();
-  });
+  SillyFirebase.renderAvatarDisplay('game-avatar', user);
 });
 </script>
 </body>

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -656,6 +656,7 @@ function saveProgress() {
                ? SillyFirebase.currentUser.uid : null;
   const data = { highScore, currentLevel: level, savedAt: Date.now(), ...(uid ? { uid } : {}) };
   localStorage.setItem(PAC_SAVE_KEY, JSON.stringify(data));
+  if (uid) localStorage.setItem(`pacman_save_${uid}`, JSON.stringify(data));
   if (typeof SillyFirebase !== 'undefined') SillyFirebase.saveProgress('pacMan', data);
 }
 
@@ -1718,23 +1719,27 @@ document.getElementById('pac-exit-btn').addEventListener('click', () => {
 SillyFirebase.renderAvatarFromCache('game-avatar');
 SillyFirebase.onAuthChanged(async user => {
   if (user) {
+    const userSaveKey = `pacman_save_${user.uid}`;
+    // Load from cloud and user-specific localStorage (persists through sign-out)
     const cloud = await SillyFirebase.loadProgress('pacMan');
-    let local = null;
-    try { local = JSON.parse(localStorage.getItem(PAC_SAVE_KEY)); } catch(e) {}
+    let userLocal = null;
+    try { userLocal = JSON.parse(localStorage.getItem(userSaveKey)); } catch(e) {}
 
     let best = null;
-    if (cloud && local) {
-      best = (cloud.savedAt || 0) > (local.savedAt || 0) ? cloud : local;
+    if (cloud && userLocal) {
+      best = (cloud.savedAt || 0) >= (userLocal.savedAt || 0) ? cloud : userLocal;
     } else {
-      best = cloud || local;
+      best = cloud || userLocal;
     }
     if (best) {
-      highScore = best.highScore || 0;
+      highScore  = best.highScore || 0;
       savedLevel = best.currentLevel || 1;
       localStorage.setItem('pacman_hs', highScore);
       localStorage.setItem(PAC_SAVE_KEY, JSON.stringify(best));
-      if ((cloud && local) && (local.savedAt || 0) > (cloud.savedAt || 0)) {
-        await SillyFirebase.saveProgress('pacMan', local);
+      localStorage.setItem(userSaveKey, JSON.stringify(best));
+      // Sync local→cloud if local is newer
+      if (userLocal && (!cloud || (userLocal.savedAt || 0) > (cloud.savedAt || 0))) {
+        await SillyFirebase.saveProgress('pacMan', userLocal);
       }
     }
   } else {

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -1735,11 +1735,18 @@ SillyFirebase.onAuthChanged(async user => {
       }
     }
   } else {
-    // Guest — read from localStorage (may have guest save)
+    // Guest — only use localStorage save if it has no uid (genuine guest save)
     try {
       const local = JSON.parse(localStorage.getItem(PAC_SAVE_KEY));
-      if (local) { savedLevel = local.currentLevel || 1; highScore = local.highScore || 0; }
-      else { savedLevel = 1; }
+      if (local && !local.uid) {
+        savedLevel = local.currentLevel || 1;
+        highScore  = local.highScore || 0;
+      } else {
+        // Signed-in user's save — discard so guest starts fresh
+        localStorage.removeItem(PAC_SAVE_KEY);
+        savedLevel = 1;
+        highScore  = parseInt(localStorage.getItem('pacman_hs') || '0', 10);
+      }
     } catch(e) { savedLevel = 1; }
   }
   // Re-draw title screen if game hasn't started yet

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -1524,6 +1524,7 @@ document.getElementById('pac-exit-btn').addEventListener('click', () => {
   window.location.href = '../../';
 });
 
+SillyFirebase.renderAvatarFromCache('game-avatar');
 SillyFirebase.onAuthChanged(async user => {
   if (user) {
     const cloud = await SillyFirebase.loadProgress('pacMan');

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -1776,7 +1776,9 @@ SillyFirebase.onAuthChanged(async user => {
   }
   // Re-draw title screen if game hasn't started yet
   if (!gameRunning) { drawMaze(); drawPac(); drawTray(); drawSoundIcon(); drawStartPrompt(); }
-  SillyFirebase.renderAvatar('game-avatar', user);
+  SillyFirebase.renderAvatar('game-avatar', user, () => {
+    if (gameRunning && !paused && !gameOver && !youWin) togglePause();
+  });
 });
 </script>
 </body>

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -963,6 +963,7 @@ function loop(now) {
         clearProgress();
       } else {
         level++;
+        saveProgress();
         startLevel();
         updateSidePanel();
       }

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -16,7 +16,7 @@ body {
   font-family: 'Courier New', monospace;
 }
 #pac-topbar {
-  width: 576px;
+  width: 980px;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -51,6 +51,7 @@ canvas {
   color: #fff;
   line-height: 1.7;
   flex-shrink: 0;
+  margin-top: 32px;
 }
 .pac-side-panel h3 {
   color: #ffd700;

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -1717,6 +1717,23 @@ document.getElementById('pac-exit-btn').addEventListener('click', () => {
 });
 
 SillyFirebase.renderAvatarFromCache('game-avatar');
+
+// Pre-load savedLevel from user-specific localStorage using cached uid —
+// eliminates the title screen pop-in delay before onAuthChanged resolves.
+(function() {
+  try {
+    const cached = JSON.parse(localStorage.getItem(SillyFirebase._AVATAR_CACHE_KEY));
+    if (cached && cached.uid) {
+      const userSave = JSON.parse(localStorage.getItem(`pacman_save_${cached.uid}`));
+      if (userSave && userSave.currentLevel > 1) {
+        savedLevel = userSave.currentLevel;
+        highScore  = userSave.highScore || highScore;
+        localStorage.setItem('pacman_hs', highScore);
+      }
+    }
+  } catch(e) {}
+})();
+
 SillyFirebase.onAuthChanged(async user => {
   if (user) {
     const userSaveKey = `pacman_save_${user.uid}`;

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -41,20 +41,20 @@ canvas {
   gap: 12px;
 }
 .pac-side-panel {
-  width: 140px;
+  width: 190px;
   background: #0a0a18;
   border: 1px solid #1a1aff;
   border-radius: 8px;
-  padding: 12px 10px;
+  padding: 14px 12px;
   font-family: 'Courier New', monospace;
-  font-size: 13px;
+  font-size: 15px;
   color: #fff;
-  line-height: 1.8;
+  line-height: 1.7;
   flex-shrink: 0;
 }
 .pac-side-panel h3 {
   color: #ffd700;
-  font-size: 11px;
+  font-size: 13px;
   letter-spacing: 1.5px;
   text-transform: uppercase;
   margin-bottom: 8px;
@@ -67,17 +67,17 @@ canvas {
   background: #1a1a3a;
   border: 1px solid #3a3a60;
   border-radius: 3px;
-  padding: 0 4px;
-  font-size: 11px;
+  padding: 0 5px;
+  font-size: 13px;
   color: #fff;
 }
 .pac-side-panel .section { margin-top: 10px; padding-top: 8px; border-top: 1px solid #1a1a40; }
-@media (max-width: 900px) {
+@media (max-width: 1050px) {
   .pac-side-panel { display: none; }
 }
 .panel-word-slot { margin-top: 8px; }
 .panel-word-label {
-  font-size: 10px;
+  font-size: 12px;
   color: #888;
   letter-spacing: 0.5px;
   margin-bottom: 3px;
@@ -87,15 +87,15 @@ canvas {
 .panel-letter-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 2px;
+  gap: 3px;
 }
 .panel-letter-box {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 16px;
-  height: 18px;
-  font-size: 11px;
+  width: 20px;
+  height: 22px;
+  font-size: 13px;
   font-weight: bold;
   font-family: 'Courier New', monospace;
   border-radius: 2px;

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -31,16 +31,129 @@ canvas {
 #game-avatar{display:flex;align-items:center;margin-left:0.5rem;}
 #pac-exit-btn{background:linear-gradient(135deg,#dc2626,#991b1b);border:1px solid #991b1b;color:#fff;font-family:monospace;font-size:0.85rem;padding:0.45rem 1rem;border-radius:8px;cursor:pointer;letter-spacing:.5px;transition:opacity 0.15s;}
 #pac-exit-btn:hover{opacity:0.85;}
+#pac-pause-btn{background:#1c1c38;border:1px solid #3a3a60;color:#ffd700;font-family:monospace;font-size:0.85rem;padding:0.45rem 1rem;border-radius:8px;cursor:pointer;letter-spacing:.5px;margin-right:0.5rem;transition:background 0.15s;}
+#pac-pause-btn:hover{background:#2a2a55;}
 #pac-canvas-wrap{position:relative;display:inline-block;}
+
+.pac-game-wrap {
+  display: flex;
+  align-items: stretch;
+  gap: 12px;
+}
+.pac-side-panel {
+  width: 140px;
+  background: #0a0a18;
+  border: 1px solid #1a1aff;
+  border-radius: 8px;
+  padding: 12px 10px;
+  font-family: 'Courier New', monospace;
+  font-size: 13px;
+  color: #fff;
+  line-height: 1.8;
+  flex-shrink: 0;
+}
+.pac-side-panel h3 {
+  color: #ffd700;
+  font-size: 11px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+  padding-bottom: 5px;
+  border-bottom: 1px solid #1a1aff;
+}
+.pac-side-panel .tip { margin-bottom: 5px; color: #fff; }
+.pac-side-panel .key {
+  display: inline-block;
+  background: #1a1a3a;
+  border: 1px solid #3a3a60;
+  border-radius: 3px;
+  padding: 0 4px;
+  font-size: 11px;
+  color: #fff;
+}
+.pac-side-panel .section { margin-top: 10px; padding-top: 8px; border-top: 1px solid #1a1a40; }
+@media (max-width: 900px) {
+  .pac-side-panel { display: none; }
+}
+.panel-word-slot { margin-top: 8px; }
+.panel-word-label {
+  font-size: 10px;
+  color: #888;
+  letter-spacing: 0.5px;
+  margin-bottom: 3px;
+}
+.panel-word-label.active { color: #aaa; }
+.panel-word-label.done   { color: #ffd700; }
+.panel-letter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+.panel-letter-box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 18px;
+  font-size: 11px;
+  font-weight: bold;
+  font-family: 'Courier New', monospace;
+  border-radius: 2px;
+  border: 1px solid #333;
+  color: #333;
+  background: #111;
+}
+.panel-letter-box.collected {
+  border-color: #aaff00;
+  color: #aaff00;
+  background: #0a1a00;
+}
+.panel-letter-box.done-word {
+  border-color: #ffd700;
+  color: #ffd700;
+  background: #1a1400;
+}
+.panel-letter-box.future {
+  border-color: #222;
+  color: #222;
+  background: #0a0a0a;
+}
 </style>
 </head>
 <body>
 <div id="pac-topbar">
+  <button id="pac-pause-btn">⏸ PAUSE</button>
   <button id="pac-exit-btn">✕ EXIT</button>
   <div id="game-avatar"></div>
 </div>
-<div id="pac-canvas-wrap">
-  <canvas id="c" width="576" height="412"></canvas><!-- 352 maze + 60 tray -->
+<div class="pac-game-wrap">
+  <div class="pac-side-panel" id="pac-panel-left">
+    <h3>Controls</h3>
+    <div class="tip"><span class="key">↑</span><span class="key">↓</span><span class="key">←</span><span class="key">→</span> Move</div>
+    <div class="tip"><span class="key">P</span> Pause / Resume</div>
+    <div class="tip">Collect letters to spell each word</div>
+    <div class="section">
+      <h3>Tips</h3>
+      <div class="tip">🟡 Power pellet → ghosts turn blue</div>
+      <div class="tip">👻 Eat blue ghost → bonus points</div>
+      <div class="tip">Spell 3 words → next level</div>
+    </div>
+  </div>
+
+  <div id="pac-canvas-wrap">
+    <canvas id="c" width="576" height="412"></canvas><!-- 352 maze + 60 tray -->
+  </div>
+
+  <div class="pac-side-panel" id="pac-panel-right">
+    <h3>Progress</h3>
+    <div id="panel-level" class="tip">Level —</div>
+    <div id="panel-word-slots"></div>
+    <div class="section">
+      <h3>Score</h3>
+      <div id="panel-score" class="tip">0</div>
+      <div id="panel-hiscore" class="tip" style="color:#ffd700">HI 0</div>
+    </div>
+  </div>
 </div>
 <script src="../shared/words.js"></script>
 <script>
@@ -450,7 +563,7 @@ document.addEventListener('keydown', e => {
   }
   if ((e.key === 'p' || e.key === 'P' || e.key === 'Escape') &&
       gameRunning && !gameOver && !dying) {
-    paused = !paused;
+    togglePause();
   }
   if (e.key === 'm' || e.key === 'M') toggleSound();
 });
@@ -491,16 +604,18 @@ function tryEat() {
   lastEatCol = cc; lastEatRow = r;
   if (r < 0 || r >= ROWS) return;
   const cell = dots[r][cc];
-  if (cell === D) { dots[r][cc] = null; score += 10; dotsLeft--; playChomp(); }
-  if (cell === P) { dots[r][cc] = null; score += 50; dotsLeft--; triggerFrightened(); playPellet(); }
+  if (cell === D) { dots[r][cc] = null; score += 10; dotsLeft--; playChomp(); updateSidePanel(); }
+  if (cell === P) { dots[r][cc] = null; score += 50; dotsLeft--; triggerFrightened(); playPellet(); updateSidePanel(); }
   if (cell === L) {
     const idx = letterIdxMap[r][cc];
     dots[r][cc] = null; score += 15; dotsLeft--; playChomp();
     if (idx >= 0) {
       collected[idx] = true;
+      updateSidePanel();
       if (collected.every(Boolean)) {
         const bonus = 100 * currentWord.length;
         score += bonus;
+        completedWords[wordsThisLevel] = true;
         wordsThisLevel++;
         wordFlash = { text: `${currentWord}! +${bonus}`, timer: 2.5 };
         playWordFound();
@@ -509,6 +624,7 @@ function tryEat() {
         } else {
           levelClear = true;
         }
+        updateSidePanel();
       }
     }
   }
@@ -557,6 +673,13 @@ function startLevel() {
   wordIndex = 0;
   wordFlash = null;
   wordsThisLevel = 0;
+  completedWords = [false, false, false];
+  // Pre-pick all 3 words for this level
+  levelWords = [
+    shuffledWords[wordIndex++] || '',
+    shuffledWords[wordIndex++] || '',
+    shuffledWords[wordIndex++] || ''
+  ];
   initWord();
   initGhosts();
   dying = false;
@@ -576,6 +699,7 @@ function startGame() {
   youWin   = false;
   paused   = false;
   startLevel();
+  updateSidePanel();
   gameRunning = true;
   lastTime = performance.now();
   requestAnimationFrame(loop);
@@ -774,6 +898,15 @@ function drawYouWin() {
 // ── Game loop ─────────────────────────────────────────────
 let paused = false;
 
+function togglePause() {
+  if (!gameRunning || gameOver || dying) return;
+  paused = !paused;
+  const btn = document.getElementById('pac-pause-btn');
+  if (btn) btn.textContent = paused ? '▶ RESUME' : '⏸ PAUSE';
+}
+
+document.getElementById('pac-pause-btn').addEventListener('click', togglePause);
+
 function drawPaused() {
   ctx.fillStyle = 'rgba(0,0,0,0.55)';
   ctx.fillRect(0, CH / 2 - 40, CW, 80);
@@ -828,6 +961,7 @@ function loop(now) {
       } else {
         level++;
         startLevel();
+        updateSidePanel();
       }
     }
   }
@@ -1131,6 +1265,7 @@ function checkGhostCollision() {
       g.mode = 'eyes';
       score += 200;
       playGhostEaten();
+      updateSidePanel();
     } else if (g.mode !== 'eyes' && !dying) {
       dying = true;
       lives--;
@@ -1217,10 +1352,12 @@ function drawGhost(g) {
 
 // ── Word state ─────────────────────────────────────────────
 // WORD_LIST provided by games/shared/words.js
-let shuffledWords = [];
-let wordIndex     = 0;
-let currentWord   = '';      // e.g. 'GHOST'
-let collected     = [];      // bool[i] — true when letter i eaten
+let shuffledWords  = [];
+let wordIndex      = 0;
+let levelWords     = ['', '', ''];  // all 3 words pre-picked for this level
+let completedWords = [false, false, false]; // which have been collected
+let currentWord    = '';      // e.g. 'GHOST'
+let collected      = [];      // bool[i] — true when letter i eaten
 let letterMap     = [];      // letterMap[r][c] = 'A'..'Z' or null
 let letterIdxMap  = [];      // letterIdxMap[r][c] = index into currentWord
 let wordFlash     = null;    // { text, timer }
@@ -1231,12 +1368,8 @@ function initWord() {
     for (let c = 0; c < COLS; c++)
       if (dots[r][c] === L) { dots[r][c] = null; dotsLeft--; }
 
-  // Reshuffle when exhausted
-  if (wordIndex >= shuffledWords.length) {
-    shuffledWords = [...WORD_LIST].sort(() => Math.random() - 0.5);
-    wordIndex = 0;
-  }
-  currentWord = shuffledWords[wordIndex++];
+  // Use the pre-picked word for this slot
+  currentWord = levelWords[wordsThisLevel] || '';
   collected   = new Array(currentWord.length).fill(false);
 
   letterMap    = Array.from({ length: ROWS }, () => Array(COLS).fill(null));
@@ -1254,6 +1387,60 @@ function initWord() {
     dots[r][c]        = L;
     letterMap[r][c]   = currentWord[i];  // uppercase
     letterIdxMap[r][c] = i;
+  }
+  updateSidePanel();
+}
+
+// ── Side panel update ──────────────────────────────────────
+function updateSidePanel() {
+  const elLevel = document.getElementById('panel-level');
+  const elSlots = document.getElementById('panel-word-slots');
+  const elScore = document.getElementById('panel-score');
+  const elHi    = document.getElementById('panel-hiscore');
+  if (!elLevel) return;
+  elLevel.textContent = 'Level ' + level;
+  elScore.textContent = score.toLocaleString();
+  elHi.textContent    = 'HI ' + highScore.toLocaleString();
+
+  if (!elSlots) return;
+  elSlots.innerHTML = '';
+  for (let wi = 0; wi < 3; wi++) {
+    const word = levelWords[wi] || '';
+    const isDone   = completedWords[wi];
+    const isActive = !isDone && wi === wordsThisLevel;
+    const isFuture = !isDone && wi > wordsThisLevel;
+
+    const slot = document.createElement('div');
+    slot.className = 'panel-word-slot';
+
+    const label = document.createElement('div');
+    label.className = 'panel-word-label' + (isDone ? ' done' : isActive ? ' active' : '');
+    label.textContent = isDone ? 'WORD ' + (wi + 1) + ' ✓' : 'WORD ' + (wi + 1);
+    slot.appendChild(label);
+
+    const row = document.createElement('div');
+    row.className = 'panel-letter-row';
+
+    if (word) {
+      for (let li = 0; li < word.length; li++) {
+        const box = document.createElement('div');
+        if (isDone) {
+          box.className = 'panel-letter-box done-word';
+          box.textContent = word[li];
+        } else if (isFuture) {
+          box.className = 'panel-letter-box future';
+          box.textContent = word[li];
+        } else {
+          // active word
+          box.className = 'panel-letter-box' + (collected[li] ? ' collected' : '');
+          box.textContent = collected[li] ? word[li] : '_';
+        }
+        row.appendChild(box);
+      }
+    }
+
+    slot.appendChild(row);
+    elSlots.appendChild(slot);
   }
 }
 

--- a/games/pac-man/index.html
+++ b/games/pac-man/index.html
@@ -652,7 +652,9 @@ function saveProgress() {
     highScore = score;
     localStorage.setItem('pacman_hs', highScore);
   }
-  const data = { highScore, currentLevel: level, savedAt: Date.now() };
+  const uid  = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser)
+               ? SillyFirebase.currentUser.uid : null;
+  const data = { highScore, currentLevel: level, savedAt: Date.now(), ...(uid ? { uid } : {}) };
   localStorage.setItem(PAC_SAVE_KEY, JSON.stringify(data));
   if (typeof SillyFirebase !== 'undefined') SillyFirebase.saveProgress('pacMan', data);
 }

--- a/games/ping-pong/index.html
+++ b/games/ping-pong/index.html
@@ -786,6 +786,7 @@ document.getElementById('soundBtn').addEventListener('click', () => {
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
+SillyFirebase.renderAvatarFromCache('game-avatar');
 SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
 </script>
 </body>

--- a/games/ping-pong/index.html
+++ b/games/ping-pong/index.html
@@ -786,8 +786,8 @@ document.getElementById('soundBtn').addEventListener('click', () => {
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
-SillyFirebase.renderAvatarFromCache('game-avatar');
-SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatar('game-avatar', user));
+SillyFirebase.renderAvatarFromCacheDisplay('game-avatar');
+SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatarDisplay('game-avatar', user));
 </script>
 </body>
 </html>

--- a/games/shared/firebase.js
+++ b/games/shared/firebase.js
@@ -84,6 +84,7 @@ const SillyFirebase = {
   signIn(onBeforePopup) {
     if (typeof onBeforePopup === 'function') onBeforePopup();
     const provider = new firebase.auth.GoogleAuthProvider();
+    provider.setCustomParameters({ prompt: 'select_account' });
     _sfAuth.signInWithPopup(provider).catch(e => console.warn('[SillyFirebase] sign-in failed', e));
   },
 

--- a/games/shared/firebase.js
+++ b/games/shared/firebase.js
@@ -157,11 +157,13 @@ const SillyFirebase = {
   renderAvatarFromCache(elementId) {
     try {
       const cached = JSON.parse(localStorage.getItem(this._AVATAR_CACHE_KEY));
-      if (cached) this._renderAvatarCircle(elementId, cached.initial, cached.color);
+      if (cached) {
+        this._renderAvatarCircle(elementId, cached.initial, cached.color, true);
+      }
     } catch(e) {}
   },
 
-  _renderAvatarCircle(elementId, initial, color) {
+  _renderAvatarCircle(elementId, initial, color, clickable = false) {
     const el = document.getElementById(elementId);
     if (!el) return;
     el.innerHTML = `<div style="
@@ -170,12 +172,17 @@ const SillyFirebase = {
       font-size:16px;font-weight:700;font-family:sans-serif;
       display:flex;align-items:center;justify-content:center;
       box-shadow:0 2px 6px rgba(0,0,0,0.3);
-      user-select:none;">${initial}</div>`;
+      user-select:none;${clickable ? 'cursor:pointer;' : ''}"
+      ${clickable ? 'title="Sign out"' : ''}>${initial}</div>`;
+    if (clickable && el.firstChild) {
+      el.firstChild.addEventListener('click', () => this.signOut());
+    }
   },
 
-  // Render a read-only avatar circle (initial letter) into an element.
-  // Shows when signed in, clears when signed out.
-  renderAvatar(elementId, user) {
+  // Render avatar circle (signed in) or Sign In button (signed out).
+  // onSignIn — optional callback fired before the Google popup opens
+  //            (use this to pause the game, etc.)
+  renderAvatar(elementId, user, onSignIn) {
     const el = document.getElementById(elementId);
     if (!el) return;
     if (user) {
@@ -183,9 +190,15 @@ const SillyFirebase = {
       const initial = name.charAt(0).toUpperCase();
       const color = this.avatarColor(name);
       this._cacheAvatar(user);
-      this._renderAvatarCircle(elementId, initial, color);
+      this._renderAvatarCircle(elementId, initial, color, true);
     } else {
-      el.innerHTML = '';
+      el.innerHTML = `<button style="
+        background:#1c1c38;border:1px solid #3a3a60;color:#aaa;
+        font-family:monospace;font-size:10px;padding:4px 8px;
+        border-radius:4px;cursor:pointer;letter-spacing:.5px;
+        white-space:nowrap;">Sign In</button>`;
+      el.firstChild.addEventListener('click', () =>
+        this.signIn(typeof onSignIn === 'function' ? onSignIn : undefined));
     }
   },
 

--- a/games/shared/firebase.js
+++ b/games/shared/firebase.js
@@ -95,8 +95,16 @@ const SillyFirebase = {
   // callback(user) is called whenever the user signs in or out.
   // Also keeps SillyFirebase.currentUser in sync.
   onAuthChanged(callback) {
+    let firstCall = true;
     _sfAuth.onAuthStateChanged(user => {
       this.currentUser = user;
+      if (user) {
+        this._cacheAvatar(user);
+      } else if (!firstCall) {
+        // Real sign-out — clear cache. Skip on initial null flash at page load.
+        this._clearAvatarCache();
+      }
+      firstCall = false;
       callback(user);
     });
   },
@@ -120,11 +128,48 @@ const SillyFirebase = {
 
   // ─── Avatar indicator ────────────────────────────────────────
 
+  _AVATAR_CACHE_KEY: '_sfAvatarCache',
+
   // Generate a consistent HSL color from a string (display name or email).
   avatarColor(str) {
     let hash = 0;
     for (let i = 0; i < str.length; i++) hash = str.charCodeAt(i) + ((hash << 5) - hash);
     return `hsl(${Math.abs(hash) % 360}, 65%, 48%)`;
+  },
+
+  _cacheAvatar(user) {
+    const name = user.displayName || user.email || '?';
+    try {
+      localStorage.setItem(this._AVATAR_CACHE_KEY, JSON.stringify({
+        initial: name.charAt(0).toUpperCase(),
+        color: this.avatarColor(name)
+      }));
+    } catch(e) {}
+  },
+
+  _clearAvatarCache() {
+    try { localStorage.removeItem(this._AVATAR_CACHE_KEY); } catch(e) {}
+  },
+
+  // Render avatar immediately from localStorage cache (no async).
+  // Call this before onAuthChanged to avoid pop-in delay for returning users.
+  renderAvatarFromCache(elementId) {
+    try {
+      const cached = JSON.parse(localStorage.getItem(this._AVATAR_CACHE_KEY));
+      if (cached) this._renderAvatarCircle(elementId, cached.initial, cached.color);
+    } catch(e) {}
+  },
+
+  _renderAvatarCircle(elementId, initial, color) {
+    const el = document.getElementById(elementId);
+    if (!el) return;
+    el.innerHTML = `<div style="
+      width:36px;height:36px;border-radius:50%;
+      background:${color};color:#fff;
+      font-size:16px;font-weight:700;font-family:sans-serif;
+      display:flex;align-items:center;justify-content:center;
+      box-shadow:0 2px 6px rgba(0,0,0,0.3);
+      user-select:none;">${initial}</div>`;
   },
 
   // Render a read-only avatar circle (initial letter) into an element.
@@ -136,13 +181,8 @@ const SillyFirebase = {
       const name = user.displayName || user.email || '?';
       const initial = name.charAt(0).toUpperCase();
       const color = this.avatarColor(name);
-      el.innerHTML = `<div style="
-        width:36px;height:36px;border-radius:50%;
-        background:${color};color:#fff;
-        font-size:16px;font-weight:700;font-family:sans-serif;
-        display:flex;align-items:center;justify-content:center;
-        box-shadow:0 2px 6px rgba(0,0,0,0.3);
-        user-select:none;">${initial}</div>`;
+      this._cacheAvatar(user);
+      this._renderAvatarCircle(elementId, initial, color);
     } else {
       el.innerHTML = '';
     }

--- a/games/shared/firebase.js
+++ b/games/shared/firebase.js
@@ -142,7 +142,8 @@ const SillyFirebase = {
     try {
       localStorage.setItem(this._AVATAR_CACHE_KEY, JSON.stringify({
         initial: name.charAt(0).toUpperCase(),
-        color: this.avatarColor(name)
+        color: this.avatarColor(name),
+        uid: user.uid
       }));
     } catch(e) {}
   },

--- a/games/shared/firebase.js
+++ b/games/shared/firebase.js
@@ -157,9 +157,7 @@ const SillyFirebase = {
   renderAvatarFromCache(elementId) {
     try {
       const cached = JSON.parse(localStorage.getItem(this._AVATAR_CACHE_KEY));
-      if (cached) {
-        this._renderAvatarCircle(elementId, cached.initial, cached.color, true);
-      }
+      if (cached) this._renderAvatarCircle(elementId, cached.initial, cached.color, true);
     } catch(e) {}
   },
 
@@ -172,14 +170,49 @@ const SillyFirebase = {
       font-size:16px;font-weight:700;font-family:sans-serif;
       display:flex;align-items:center;justify-content:center;
       box-shadow:0 2px 6px rgba(0,0,0,0.3);
-      user-select:none;${clickable ? 'cursor:pointer;' : ''}"
-      ${clickable ? 'title="Sign out"' : ''}>${initial}</div>`;
+      user-select:none;${clickable ? 'cursor:pointer;' : ''}">${initial}</div>`;
     if (clickable && el.firstChild) {
-      el.firstChild.addEventListener('click', () => this.signOut());
+      el.firstChild.addEventListener('click', (e) => {
+        e.stopPropagation();
+        this._toggleAvatarPopup(el.firstChild);
+      });
     }
   },
 
-  // Render avatar circle (signed in) or Sign In button (signed out).
+  _toggleAvatarPopup(anchor) {
+    const existing = document.getElementById('_sf_avatar_popup');
+    if (existing) { existing.remove(); return; }
+    const user = this.currentUser;
+    if (!user) return;
+    const name = user.displayName || user.email || '?';
+    const rect = anchor.getBoundingClientRect();
+    const popup = document.createElement('div');
+    popup.id = '_sf_avatar_popup';
+    popup.style.cssText = `
+      position:fixed;top:${rect.bottom + 8}px;right:${window.innerWidth - rect.right}px;
+      background:#1a1a2e;border:1px solid #3a3a60;border-radius:10px;
+      padding:14px 16px;min-width:200px;
+      box-shadow:0 4px 20px rgba(0,0,0,0.6);z-index:9999;font-family:sans-serif;`;
+    popup.innerHTML = `
+      <div style="font-weight:700;font-size:14px;color:#fff;margin-bottom:3px;">Hi, ${name}!</div>
+      <div style="font-size:12px;color:#888;margin-bottom:12px;">${user.email || ''}</div>
+      <button id="_sf_so_btn" style="width:100%;padding:8px;background:#1c1c38;
+        border:1px solid #3a3a60;color:#ccc;border-radius:6px;cursor:pointer;
+        font-size:13px;font-family:sans-serif;">Sign Out</button>`;
+    document.body.appendChild(popup);
+    popup.querySelector('#_sf_so_btn').addEventListener('click', () => {
+      popup.remove(); this.signOut();
+    });
+    const close = (e) => {
+      if (!popup.contains(e.target) && !anchor.contains(e.target)) {
+        popup.remove();
+        document.removeEventListener('click', close, true);
+      }
+    };
+    setTimeout(() => document.addEventListener('click', close, true), 0);
+  },
+
+  // Render avatar circle (signed in) or compact sign-in circle (signed out).
   // onSignIn — optional callback fired before the Google popup opens
   //            (use this to pause the game, etc.)
   renderAvatar(elementId, user, onSignIn) {
@@ -192,11 +225,12 @@ const SillyFirebase = {
       this._cacheAvatar(user);
       this._renderAvatarCircle(elementId, initial, color, true);
     } else {
-      el.innerHTML = `<button style="
-        background:#1c1c38;border:1px solid #3a3a60;color:#aaa;
-        font-family:monospace;font-size:10px;padding:4px 8px;
-        border-radius:4px;cursor:pointer;letter-spacing:.5px;
-        white-space:nowrap;">Sign In</button>`;
+      // Same 36×36 size as avatar circle so topbar width never changes
+      el.innerHTML = `<div style="
+        width:36px;height:36px;border-radius:50%;
+        border:2px dashed #3a3a60;color:#666;font-size:20px;
+        display:flex;align-items:center;justify-content:center;
+        cursor:pointer;user-select:none;" title="Sign in">+</div>`;
       el.firstChild.addEventListener('click', () =>
         this.signIn(typeof onSignIn === 'function' ? onSignIn : undefined));
     }

--- a/games/shared/firebase.js
+++ b/games/shared/firebase.js
@@ -237,6 +237,33 @@ const SillyFirebase = {
     }
   },
 
+  // ─── Display-only avatar (in-game use — no sign-in/out interaction) ─────────
+
+  // Like renderAvatarFromCache but never adds a click handler.
+  renderAvatarFromCacheDisplay(elementId) {
+    try {
+      const cached = JSON.parse(localStorage.getItem(this._AVATAR_CACHE_KEY));
+      if (cached) this._renderAvatarCircle(elementId, cached.initial, cached.color, false);
+    } catch(e) {}
+  },
+
+  // Show avatar (signed in) or a dim placeholder (signed out). No interactivity.
+  renderAvatarDisplay(elementId, user) {
+    const el = document.getElementById(elementId);
+    if (!el) return;
+    if (user) {
+      const name = user.displayName || user.email || '?';
+      this._cacheAvatar(user);
+      this._renderAvatarCircle(elementId, name.charAt(0).toUpperCase(), this.avatarColor(name), false);
+    } else {
+      el.innerHTML = `<div style="
+        width:36px;height:36px;border-radius:50%;
+        border:2px dashed #3a3a60;color:#444;font-size:20px;
+        display:flex;align-items:center;justify-content:center;
+        user-select:none;" title="Sign in from lobby"></div>`;
+    }
+  },
+
   // ─── Visit tracking ──────────────────────────────────────────
 
   // Increment visit counter for pageId and return the new total.

--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
       background-clip: text;
     }
     .hero p {
-      color: #fff;
+      color: var(--muted);
       font-size: 1.05rem;
       white-space: nowrap;
     }

--- a/index.html
+++ b/index.html
@@ -156,9 +156,9 @@
       background-clip: text;
     }
     .hero p {
-      color: var(--muted);
+      color: #fff;
       font-size: 1.05rem;
-      max-width: 520px;
+      white-space: nowrap;
     }
 
     /* ── SECTION ── */


### PR DESCRIPTION
## Summary
- Avatar in all games is now display-only — sign-in/out from lobby only
- Blocks Classic: full level/lines/score save for signed-in users and guests
- Bounce Rush: linear level progression + Continue/New Game save
- Pac-Man: guest/sign-in level save, Continue pop-in delay fix
- Google account picker always shown on sign-in
- Lobby subtitle fix

## Issues closed
Fixes #79, #80, #81, #82, #83, #84, #85

## Test plan
- Lobby sign-in/out works; avatar clickable in lobby, display-only in all games
- Blocks Classic: Continue (Level X) for signed-in users; guest session save
- Bounce Rush: linear progression, Continue for signed-in users
- Pac-Man: level save persists across sign-out/sign-in

Generated with [Claude Code](https://claude.com/claude-code)