### PR TITLE
fix: Blocks Classic modal width, Continue delay for all games, Count Masters level save

### DIFF
--- a/games/blocks-classic/index.html
+++ b/games/blocks-classic/index.html
@@ -338,6 +338,7 @@
     <div class="modal-buttons" style="display:flex;gap:0.6rem;flex-wrap:wrap;justify-content:center;">
       <button class="btn btn-secondary" id="continueBtn" style="display:none;min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">▶ Continue</button>
       <button class="btn btn-primary" id="startBtn" style="min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
+      <button class="btn btn-danger" onclick="window.location.href='../../'" style="min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">✕ Exit to Lobby</button>
     </div>
   </div>
 </div>

--- a/games/blocks-classic/index.html
+++ b/games/blocks-classic/index.html
@@ -338,7 +338,7 @@
     <div class="modal-buttons" style="display:flex;gap:0.6rem;flex-wrap:wrap;justify-content:center;">
       <button class="btn btn-secondary" id="continueBtn" style="display:none;min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">▶ Continue</button>
       <button class="btn btn-primary" id="startBtn" style="min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
-      <button class="btn btn-danger" onclick="window.location.href='../../'" style="min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">✕ Exit to Lobby</button>
+      <button class="btn btn-danger" onclick="window.location.href='../../'" style="min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">✕ EXIT</button>
     </div>
   </div>
 </div>

--- a/games/blocks-classic/index.html
+++ b/games/blocks-classic/index.html
@@ -178,7 +178,7 @@
       border: 1px solid var(--border);
       border-radius: 18px;
       padding: 2rem 2.2rem;
-      max-width: 420px;
+      max-width: 560px;
       width: 90%;
       text-align: center;
     }
@@ -239,7 +239,7 @@
       justify-content: center;
       margin-top: 0.4rem;
     }
-    .modal-buttons .btn { min-width: 120px; }
+    .modal-buttons .btn { white-space: nowrap; }
 
     /* Pause indicator */
     .pause-badge {
@@ -335,10 +335,10 @@
       Fill complete horizontal lines to clear them and score points.<br>
       Speed increases every 10 lines. Don't let blocks reach the top!
     </p>
-    <div class="modal-buttons" style="display:flex;gap:0.6rem;flex-wrap:wrap;justify-content:center;">
-      <button class="btn btn-secondary" id="continueBtn" style="display:none;min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">▶ Continue</button>
-      <button class="btn btn-primary" id="startBtn" style="min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
-      <button class="btn btn-danger" onclick="window.location.href='../../'" style="min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">✕ EXIT</button>
+    <div class="modal-buttons" style="display:flex;gap:0.6rem;justify-content:center;">
+      <button class="btn btn-secondary" id="continueBtn" style="display:none;font-size:1rem;padding:0.7rem 1.5rem">▶ Continue</button>
+      <button class="btn btn-primary" id="startBtn" style="font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
+      <button class="btn btn-danger" onclick="window.location.href='../../'" style="font-size:1rem;padding:0.7rem 1.5rem">✕ EXIT</button>
     </div>
   </div>
 </div>

--- a/games/bounce-rush/index.html
+++ b/games/bounce-rush/index.html
@@ -154,6 +154,7 @@
     <div class="modal-btns" id="modalBtns">
       <button class="modal-continue" id="modalContinueBtn" style="display:none">▶ Continue</button>
       <button class="modal-start" id="modalStartBtn">▶ Start Game</button>
+      <button class="modal-exit" id="modalExitBtn" onclick="window.location.href='../../'" style="background:linear-gradient(135deg,#dc2626,#991b1b);color:#fff;border:none;border-radius:10px;padding:0.75rem 1.5rem;font-size:1rem;font-weight:700;cursor:pointer;margin-top:0.4rem;">✕ Exit to Lobby</button>
     </div>
   </div>
 </div>
@@ -1001,12 +1002,15 @@ function openModal(isResume) {
   const continueBtn = document.getElementById('modalContinueBtn');
   const startBtn    = document.getElementById('modalStartBtn');
 
+  const exitBtn = document.getElementById('modalExitBtn');
   if (isResume) {
-    // Opened via How to Play during gameplay
+    // Opened via How to Play during gameplay — hide Exit
     continueBtn.style.display = 'none';
+    if (exitBtn) exitBtn.style.display = 'none';
     startBtn.textContent = '▶ Resume Game';
     startBtn.onclick = closeModal;
   } else {
+    if (exitBtn) exitBtn.style.display = '';
     // Title screen
     if (savedLevel > 0) {
       continueBtn.style.display = '';

--- a/games/bounce-rush/index.html
+++ b/games/bounce-rush/index.html
@@ -154,7 +154,7 @@
     <div class="modal-btns" id="modalBtns">
       <button class="modal-continue" id="modalContinueBtn" style="display:none">▶ Continue</button>
       <button class="modal-start" id="modalStartBtn">▶ Start Game</button>
-      <button class="modal-exit" id="modalExitBtn" onclick="window.location.href='../../'" style="background:linear-gradient(135deg,#dc2626,#991b1b);color:#fff;border:none;border-radius:10px;padding:0.75rem 1.5rem;font-size:1rem;font-weight:700;cursor:pointer;margin-top:0.4rem;">✕ Exit to Lobby</button>
+      <button class="modal-exit" id="modalExitBtn" onclick="window.location.href='../../'" style="background:linear-gradient(135deg,#dc2626,#991b1b);color:#fff;border:none;border-radius:10px;padding:0.75rem 1.5rem;font-size:1rem;font-weight:700;cursor:pointer;margin-top:0.4rem;">✕ EXIT</button>
     </div>
   </div>
 </div>

--- a/games/bounce-rush/index.html
+++ b/games/bounce-rush/index.html
@@ -84,14 +84,15 @@
   .modal {
     background: #1c1c38; border: 1px solid #3a3a6a;
     border-radius: 16px; padding: 1.8rem 2rem;
-    max-width: 350px; width: 92%;
+    max-width: 480px; width: 92%;
     box-shadow: 0 20px 60px rgba(0,0,0,0.6);
   }
   .modal h2 { font-size: 1.3rem; font-weight: 800; margin-bottom: 0.9rem; text-align: center; }
   .modal p  { font-size: 0.87rem; color: #94a3b8; line-height: 1.6; margin-bottom: 0.5rem; }
   .modal ul { padding-left: 1.2rem; margin-bottom: 0.8rem; }
   .modal li { font-size: 0.87rem; color: #94a3b8; line-height: 1.7; }
-  .modal-btns { display: flex; gap: 0.6rem; margin-top: 1.2rem; }
+  .modal-btns { display: flex; gap: 0.6rem; margin-top: 1.2rem; justify-content: center; }
+  .modal-btns button { white-space: nowrap; }
   .modal-start {
     flex: 1; background: linear-gradient(135deg, #7c3aed, #5b21b6);
     border: none; color: #fff; border-radius: 9px;

--- a/games/bounce-rush/index.html
+++ b/games/bounce-rush/index.html
@@ -1069,7 +1069,7 @@ openModal(false);
 <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore-compat.js"></script>
 <script src="../shared/firebase.js"></script>
 <script>
-// Pre-load savedLevel from cached uid
+// Pre-load savedLevel from cached uid — re-open modal so Continue shows immediately
 (function() {
   try {
     const cached = JSON.parse(localStorage.getItem(SillyFirebase._AVATAR_CACHE_KEY));
@@ -1077,6 +1077,7 @@ openModal(false);
       const userSave = JSON.parse(localStorage.getItem(`bounceRush_save_${cached.uid}`));
       if (userSave && userSave.currentLevel > 0) {
         savedLevel = userSave.currentLevel;
+        if (gameState === 'idle') openModal(false);
       }
     }
   } catch(e) {}

--- a/games/bubble-bobble/index.html
+++ b/games/bubble-bobble/index.html
@@ -317,6 +317,7 @@ function consume(k) { if(pressed.has(k)){pressed.delete(k);return true;} return 
 
 // ─── Save / Load ─────────────────────────────────────────────
 const SAVE_KEY = 'bubbleBobbleSave';
+let _cachedUid = null; // pre-loaded from avatar cache before auth resolves
 function saveProgress() {
   const uid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser) ? SillyFirebase.currentUser.uid : null;
   const data = { level:gs.level, score:gs.score, lives:gs.lives, wordStreak:gs.wordStreak, savedAt:Date.now(), uid };
@@ -876,7 +877,9 @@ function drawTitle(ctx, frame) {
   ctx.fillStyle='#f5c518'; ctx.font='bold 36px monospace'; ctx.fillText('BUBBLE',CW/2,CH/2-50);
   ctx.fillStyle='#4ecdc4'; ctx.font='bold 36px monospace'; ctx.fillText('BOBBLE',CW/2,CH/2-10);
   const sv = loadSave();
-  const _currentUid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser) ? SillyFirebase.currentUser.uid : null;
+  const _currentUid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser)
+    ? SillyFirebase.currentUser.uid
+    : _cachedUid;
   if(sv && sv.uid === _currentUid){
     const opts = [
       { label:'Continue (Level '+String(sv.level).padStart(2,'0')+')', color:'#4ecdc4' },
@@ -1361,8 +1364,20 @@ updateHUD();
 <script>
 // ─── Bubble Bobble Firebase wiring ───────────────────────────
 SillyFirebase.renderAvatarFromCacheDisplay('game-avatar');
+
+// Pre-load _cachedUid from avatar cache so drawTitle can show Continue immediately
+(function() {
+  try {
+    const cached = JSON.parse(localStorage.getItem('_sfAvatarCache'));
+    if (cached && cached.uid) {
+      _cachedUid = cached.uid;
+    }
+  } catch(e) {}
+})();
+
 SillyFirebase.onAuthChanged(async user => {
   SillyFirebase.renderAvatarDisplay('game-avatar', user);
+  _cachedUid = user ? user.uid : null;
   if (user) {
     await SillyFirebase.syncProgress('bubbleBobble', SAVE_KEY);
   }

--- a/games/bubble-shooter/index.html
+++ b/games/bubble-shooter/index.html
@@ -279,7 +279,7 @@
     </p>
     <div class="modal-buttons">
       <button class="btn btn-primary" id="startBtn" style="min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
-      <button class="btn btn-danger" onclick="window.location.href='../../'">✕ Exit to Lobby</button>
+      <button class="btn btn-danger" onclick="window.location.href='../../'">✕ EXIT</button>
     </div>
   </div>
 </div>

--- a/games/bubble-shooter/index.html
+++ b/games/bubble-shooter/index.html
@@ -279,6 +279,7 @@
     </p>
     <div class="modal-buttons">
       <button class="btn btn-primary" id="startBtn" style="min-width:150px;font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
+      <button class="btn btn-danger" onclick="window.location.href='../../'">✕ Exit to Lobby</button>
     </div>
   </div>
 </div>

--- a/games/count-masters/index.html
+++ b/games/count-masters/index.html
@@ -54,6 +54,7 @@
     .btn-ghost { background: transparent; border: 1px solid var(--border); color: var(--text); }
     .btn-ghost:hover { border-color: var(--accent); }
     .btn-primary { background: linear-gradient(135deg, var(--accent), #5b21b6); color: #fff; }
+    .btn-secondary { background: linear-gradient(135deg, #374151, #1f2937); color: #e2e8f0; border: 1px solid var(--border); }
     .btn-danger { background: linear-gradient(135deg, #dc2626, #991b1b); color: #fff; }
     .btn-success { background: linear-gradient(135deg, #16a34a, #15803d); color: #fff; }
 
@@ -105,7 +106,7 @@
     .modal {
       background: var(--surface); border: 1px solid var(--border);
       border-radius: 18px; padding: 2rem 2.2rem;
-      max-width: 440px; width: 90%; text-align: center;
+      max-width: 560px; width: 90%; text-align: center;
     }
     .modal h2 { font-size: 1.7rem; font-weight: 800; margin-bottom: 0.4rem; }
     .modal .subtitle { color: var(--muted); font-size: 0.9rem; margin-bottom: 1.4rem; }
@@ -125,7 +126,7 @@
     .modal .instructions .icon { font-size: 1.1rem; flex-shrink: 0; margin-top: -1px; }
     .modal-score { font-size: 2.8rem; font-weight: 900; color: var(--accent2); margin: 0.4rem 0; }
     .modal-buttons { display: flex; gap: 0.7rem; justify-content: center; margin-top: 1rem; }
-    .modal-buttons .btn { min-width: 120px; }
+    .modal-buttons .btn { white-space: nowrap; }
 
     /* Pause badge */
     .pause-badge {
@@ -253,8 +254,9 @@
       <div class="legend-item"><div class="legend-dot" style="background:#ef4444"></div> ÷2, −5, −10</div>
     </div>
     <div class="modal-buttons">
-      <button class="btn btn-primary" id="startBtn" style="min-width:160px;font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
-      <button class="btn btn-danger" onclick="window.location.href='../../'">✕ EXIT</button>
+      <button class="btn btn-secondary" id="continueBtn" style="display:none;font-size:1rem;padding:0.7rem 1.5rem">▶ Continue</button>
+      <button class="btn btn-primary" id="startBtn" style="font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
+      <button class="btn btn-danger" onclick="window.location.href='../../'" style="font-size:1rem;padding:0.7rem 1.5rem">✕ EXIT</button>
     </div>
   </div>
 </div>
@@ -477,6 +479,50 @@ let dashOffset = 0;
 // State saved when How to Play is opened mid-game
 let savedGameState = null;
 
+// ─── SAVE / LOAD ─────────────────────────────────────────────
+const CM_SAVE_KEY  = 'countMasters_save';
+const CM_GUEST_KEY = 'countMasters_guest_save';
+let savedLevel   = 0;    // 0 = no save; N > 1 = continue from level N
+let gamePlayedAs = null; // null = guest; uid = signed-in user who started current game
+
+function saveProgress() {
+  const data = { level: level, savedAt: Date.now() };
+  if (gamePlayedAs) {
+    data.uid = gamePlayedAs;
+    localStorage.setItem(CM_SAVE_KEY, JSON.stringify(data));
+    localStorage.setItem(`countMasters_save_${gamePlayedAs}`, JSON.stringify(data));
+    if (typeof SillyFirebase !== 'undefined') SillyFirebase.saveProgress('countMasters', data);
+  } else {
+    sessionStorage.setItem(CM_GUEST_KEY, JSON.stringify(data));
+  }
+}
+
+function clearSaveProgress() {
+  const uid = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser)
+    ? SillyFirebase.currentUser.uid : null;
+  if (uid) {
+    localStorage.removeItem(CM_SAVE_KEY);
+    localStorage.removeItem(`countMasters_save_${uid}`);
+    if (typeof SillyFirebase !== 'undefined') SillyFirebase.saveProgress('countMasters', null);
+  } else {
+    sessionStorage.removeItem(CM_GUEST_KEY);
+  }
+  savedLevel = 0;
+}
+
+function updateStartPanel() {
+  const continueBtn = document.getElementById('continueBtn');
+  const startBtn    = document.getElementById('startBtn');
+  if (savedLevel > 1) {
+    continueBtn.style.display = '';
+    continueBtn.textContent   = `▶ Continue (Level ${savedLevel})`;
+    startBtn.textContent      = '↺ New Game';
+  } else {
+    continueBtn.style.display = 'none';
+    startBtn.textContent      = '▶ Start Game';
+  }
+}
+
 // ═══════════════════════════════════════════════
 //  CANVAS
 // ═══════════════════════════════════════════════
@@ -545,6 +591,9 @@ function buildLevel(lvl) {
 //  INIT
 // ═══════════════════════════════════════════════
 function initGame(keepCount = false) {
+  gamePlayedAs = (typeof SillyFirebase !== 'undefined' && SillyFirebase.currentUser)
+    ? SillyFirebase.currentUser.uid : null;
+  if (level > 1) saveProgress(); // save current level so Continue resumes exactly here
   const cfg = LEVEL_CFG[Math.min(level - 1, LEVEL_CFG.length - 1)];
   if (!keepCount) count = cfg.startCount || count;
   crowdX = 0;
@@ -1331,6 +1380,7 @@ document.getElementById('startBtn').addEventListener('click', () => {
     setPauseBtnText(false);
     requestAnimationFrame(loop); // restart the stopped loop
   } else {
+    clearSaveProgress();
     level = 1;
     score = 0;
     count = 10;
@@ -1338,8 +1388,17 @@ document.getElementById('startBtn').addEventListener('click', () => {
   }
 });
 
+document.getElementById('continueBtn').addEventListener('click', () => {
+  document.getElementById('startOverlay').classList.remove('active');
+  level = savedLevel;
+  score = 0;
+  count = 10;
+  initGame();
+});
+
 document.getElementById('restartBtn').addEventListener('click', () => {
   document.getElementById('resultOverlay').classList.remove('active');
+  clearSaveProgress();
   level = 1; score = 0; count = 10;
   initGame();
 });
@@ -1352,7 +1411,12 @@ document.getElementById('howToPlayBtn').addEventListener('click', () => {
     gameState = 'paused';
     setPauseBtnText(true);
   }
-  document.getElementById('startBtn').textContent = isResumable ? '▶ Resume Game' : '▶ Start Game';
+  if (isResumable) {
+    document.getElementById('continueBtn').style.display = 'none';
+    document.getElementById('startBtn').textContent = '▶ Resume Game';
+  } else {
+    updateStartPanel();
+  }
   document.getElementById('startOverlay').classList.add('active');
 });
 
@@ -1364,6 +1428,7 @@ document.getElementById('resultContinueBtn').addEventListener('click', () => {
 
 document.getElementById('resultRestartBtn').addEventListener('click', () => {
   document.getElementById('resultOverlay').classList.remove('active');
+  clearSaveProgress();
   level = 1; score = 0; count = 10;
   initGame();
 });
@@ -1387,7 +1452,57 @@ document.getElementById('resultExitBtn').addEventListener('click', () => { windo
 <script src="../shared/firebase.js"></script>
 <script>
 SillyFirebase.renderAvatarFromCacheDisplay('game-avatar');
-SillyFirebase.onAuthChanged(user => SillyFirebase.renderAvatarDisplay('game-avatar', user));
+
+// Pre-load savedLevel from cached uid — shows Continue immediately, no pop-in
+(function() {
+  try {
+    const cached = JSON.parse(localStorage.getItem('_sfAvatarCache'));
+    if (cached && cached.uid) {
+      const userSave = JSON.parse(localStorage.getItem(`countMasters_save_${cached.uid}`));
+      if (userSave && userSave.level > 1) {
+        savedLevel = userSave.level;
+        updateStartPanel();
+      }
+    }
+  } catch(e) {}
+})();
+
+SillyFirebase.onAuthChanged(async user => {
+  SillyFirebase.renderAvatarDisplay('game-avatar', user);
+  if (user) {
+    const userSaveKey = `countMasters_save_${user.uid}`;
+    const cloud = await SillyFirebase.loadProgress('countMasters');
+    let userLocal = null;
+    try { userLocal = JSON.parse(localStorage.getItem(userSaveKey)); } catch(e) {}
+
+    let best = null;
+    if (cloud && userLocal) {
+      best = (cloud.savedAt || 0) >= (userLocal.savedAt || 0) ? cloud : userLocal;
+    } else {
+      best = cloud || userLocal;
+    }
+    if (best) {
+      savedLevel = best.level || 0;
+      const stamped = { ...best, uid: user.uid };
+      localStorage.setItem(CM_SAVE_KEY, JSON.stringify(stamped));
+      localStorage.setItem(userSaveKey, JSON.stringify(stamped));
+      if (userLocal && (!cloud || (userLocal.savedAt || 0) > (cloud.savedAt || 0))) {
+        await SillyFirebase.saveProgress('countMasters', userLocal);
+      }
+    } else {
+      savedLevel = 0;
+    }
+    if (gameState === 'idle') updateStartPanel();
+  } else {
+    localStorage.removeItem(CM_SAVE_KEY);
+    savedLevel = 0;
+    try {
+      const sess = JSON.parse(sessionStorage.getItem(CM_GUEST_KEY));
+      if (sess && !sess.uid) savedLevel = sess.level || 0;
+    } catch(e) {}
+    if (gameState === 'idle') updateStartPanel();
+  }
+});
 </script>
 </body>
 </html>

--- a/games/count-masters/index.html
+++ b/games/count-masters/index.html
@@ -254,6 +254,7 @@
     </div>
     <div class="modal-buttons">
       <button class="btn btn-primary" id="startBtn" style="min-width:160px;font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
+      <button class="btn btn-danger" onclick="window.location.href='../../'">✕ Exit to Lobby</button>
     </div>
   </div>
 </div>

--- a/games/count-masters/index.html
+++ b/games/count-masters/index.html
@@ -254,7 +254,7 @@
     </div>
     <div class="modal-buttons">
       <button class="btn btn-primary" id="startBtn" style="min-width:160px;font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
-      <button class="btn btn-danger" onclick="window.location.href='../../'">✕ Exit to Lobby</button>
+      <button class="btn btn-danger" onclick="window.location.href='../../'">✕ EXIT</button>
     </div>
   </div>
 </div>

--- a/games/ping-pong/index.html
+++ b/games/ping-pong/index.html
@@ -178,8 +178,8 @@
       <span class="key">P / Space</span><span class="desc">Pause / Resume</span>
     </div>
     <div class="modal-btns">
-      <button class="btn btn-primary" id="startBtn">▶ Start Game</button>
-      <button class="btn btn-danger" onclick="window.location.href='../../'">✕ Exit to Lobby</button>
+      <button class="btn btn-primary" id="startBtn" style="font-size:1rem;padding:0.7rem 1.5rem">▶ Start Game</button>
+      <button class="btn btn-danger" onclick="window.location.href='../../'" style="font-size:1rem;padding:0.7rem 1.5rem">✕ EXIT</button>
     </div>
   </div>
 </div>

--- a/games/ping-pong/index.html
+++ b/games/ping-pong/index.html
@@ -179,6 +179,7 @@
     </div>
     <div class="modal-btns">
       <button class="btn btn-primary" id="startBtn">▶ Start Game</button>
+      <button class="btn btn-danger" onclick="window.location.href='../../'">✕ Exit to Lobby</button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Fixes #92 — Blocks Classic start modal widened to 560px; 3 buttons fit on one row without wrapping
- Fixes #89 — Bounce Rush and Bubble Bobble now show Continue button instantly (no ~1s pop-in delay) for returning signed-in users
- Fixes #87 — Count Masters saves and restores level for signed-in users; instant Continue button via IIFE pre-loader; guest save in sessionStorage

## Test plan
- [ ] Blocks Classic: start modal shows 3 buttons (Continue / New Game / EXIT) on one row
- [ ] Bounce Rush: sign in from lobby → open game → Continue (Level N) visible immediately
- [ ] Bubble Bobble: sign in from lobby → open game → Continue option on title screen immediately
- [ ] Count Masters: sign in from lobby → open game → Continue (Level N) visible immediately; Continue starts at correct level with 10 army; New Game clears save; guest progress isolated in sessionStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)